### PR TITLE
fix: handle reducing-end O-Fuc glycans in draw_cartoon

### DIFF
--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -25,7 +25,9 @@ draw_cartoon <- function(
   highlight = NULL
 ) {
   if (!is.null(highlight) && !glyrepr::is_glycan_structure(structure)) {
-    cli::cli_warn("{.arg highlight} can only be set when {.arg structure} is a {.fn glyrepr::glycan_structure}.")
+    cli::cli_warn(
+      "{.arg highlight} can only be set when {.arg structure} is a {.fn glyrepr::glycan_structure}."
+    )
     highlight <- NULL
   }
   structure <- .ensure_one_structure(structure)
@@ -236,7 +238,9 @@ export_cartoons.glyexp_experiment <- function(
     ))
   }
   if (!"glycan_structure" %in% colnames(glyexp::get_var_info(x))) {
-    cli::cli_abort("There must a {.field glycan_structure} column in {.field var_info}.")
+    cli::cli_abort(
+      "There must a {.field glycan_structure} column in {.field var_info}."
+    )
   }
   glycans <- unique(glyexp::get_var_info(x)$glycan_structure)
   .export_cartoons(
@@ -300,8 +304,17 @@ export_cartoons.glyrepr_structure <- function(
   cli::cli_alert_info("Exporting {.val {length(glycans)}} glycan cartoons.")
   checkmate::assert_directory_exists(dirname)
   glycan_list <- purrr::map(seq_along(glycans), ~ glycans[[.x]])
-  cartoons <- purrr::map(glycan_list, draw_cartoon, show_linkage = show_linkage, orient = orient)
-  filenames <- fs::path(dirname, .sanitize_export_filenames(glycans), ext = file_ext)
+  cartoons <- purrr::map(
+    glycan_list,
+    draw_cartoon,
+    show_linkage = show_linkage,
+    orient = orient
+  )
+  filenames <- fs::path(
+    dirname,
+    .sanitize_export_filenames(glycans),
+    ext = file_ext
+  )
   purrr::walk2(cartoons, filenames, save_cartoon, dpi = dpi)
   invisible(cartoons)
 }

--- a/R/internal.R
+++ b/R/internal.R
@@ -1,4 +1,3 @@
-
 # glycan mapping
 glycan_color <- c(
   'glyWhite' = '#FFFFFF',
@@ -199,11 +198,24 @@ coor_initialization <- function(structure) {
   init_X <- igraph::distances(structure)[length(structure), ] * (-1)
   coor[, 'x'] <- init_X
   for (i in seq(1, length(structure))) {
-    if (igraph::V(structure)[[i]]$mono == 'Fuc') {
+    if (
+      igraph::V(structure)[[i]]$mono == 'Fuc' && !.is_reducing_end(structure, i)
+    ) {
       coor[i, 'x'] <- coor[i, 'x'] + 1
     }
   }
   return(coor)
+}
+
+#' Check whether a vertex is the reducing end.
+#'
+#' @param structure an igraph object.
+#' @param ver an integer vertex index.
+#'
+#' @returns A logical scalar.
+#' @noRd
+.is_reducing_end <- function(structure, ver) {
+  ver == length(structure)
 }
 
 #' Title Find Sequence Number of Sub-module
@@ -666,7 +678,7 @@ connect_info <- function(structure, coor) {
 glycoform_info <- function(structure) {
   glycoform <- igraph::V(structure)$mono
   for (i in c(which(glycoform == 'Fuc'))) {
-    if (fuc_offset(structure, i) == '0.99') {
+    if (!.is_reducing_end(structure, i) && fuc_offset(structure, i) == '0.99') {
       glycoform[i] <- 'FucUp'
     }
   }

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -26,6 +26,25 @@ test_that("draw_cartoon works with linkage hidden", {
   expect_s3_class(plot_no_linkage, "glydraw_cartoon")
 })
 
+test_that("draw_cartoon works with reducing-end O-Fuc glycans", {
+  glycans <- c(
+    "Fuc(a1-",
+    "GlcNAc(b1-3)Fuc(a1-"
+  )
+
+  cartoons <- purrr::map(glycans, draw_cartoon)
+
+  purrr::walk(cartoons, expect_s3_class, "glydraw_cartoon")
+})
+
+test_that("reducing-end Fuc keeps the regular Fuc orientation", {
+  structure <- .ensure_one_structure("GlcNAc(b1-3)Fuc(a1-")
+  graph <- glyrepr::get_structure_graphs(structure, return_list = FALSE)
+
+  expect_equal(glycoform_info(graph), c("GlcNAc", "Fuc"))
+  expect_equal(unname(coor_cal(graph)[2, "x"]), 0)
+})
+
 test_that("save_cartoon saves file correctly", {
   structure <- "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
   cartoon <- draw_cartoon(structure)
@@ -167,7 +186,9 @@ test_that("export_cartoons works with jpeg extension", {
   on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
   fs::dir_create(temp_dir)
 
-  suppressMessages(result <- export_cartoons(glycans, temp_dir, file_ext = "jpg", dpi = 72))
+  suppressMessages(
+    result <- export_cartoons(glycans, temp_dir, file_ext = "jpg", dpi = 72)
+  )
   files <- fs::dir_ls(temp_dir, glob = "*.jpg")
   expect_length(files, 1)
 })


### PR DESCRIPTION
## Summary
- Keep reducing-end Fuc residues on the regular Fuc glyph/orientation instead of treating them as upward side-branch Fuc nodes
- Add regression coverage for `Fuc(a1-` and `GlcNAc(b1-3)Fuc(a1-`
- Preserve existing export and drawing behavior for other glycans

## Testing
- `devtools::document()`
- `devtools::test(filter = "glydraw")`
- `devtools::test()`
- Visual validation with `save_cartoon()` on the two issue examples

Closes #14