### PR TITLE
Draw substituent annotations

### DIFF
--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -60,7 +60,10 @@ draw_cartoon <- function(
   polygon_coor <- create_polygon_coor(gly_list, 0.2)
   filled_color <- glycan_color[as.character(polygon_coor$color)]
 
-  struc_annotation <- gly_annotation(structure, coor)
+  struc_annotation <- dplyr::bind_rows(
+    gly_annotation(structure, coor),
+    substituent_annotation(structure, coor, orient)
+  )
   reducing_info <- reducing_end_annotation(structure, coor)
   struc_annotation <- dplyr::bind_rows(
     struc_annotation,
@@ -79,12 +82,13 @@ draw_cartoon <- function(
   struc_annotation <- struc_annotation |>
     dplyr::mutate(
       annot_label = dplyr::case_when(
-        annot == "?" ~ '~"?"',
-        annot == "??" ~ '~"?"',
+        .data$annot == "?" ~ '~"?"',
+        .data$annot == "??" ~ '~"?"',
         # case like '?3' would convert to '?'
-        grepl("^\\?\\d+", annot) ~ '~"?"',
+        grepl("^\\?\\d+", .data$annot) ~ '~"?"',
+        !is_parseable_annotation(.data$annot) ~ quote_annotation(.data$annot),
         # normal annotation would maintain the same
-        TRUE ~ struc_annotation$annot
+        TRUE ~ .data$annot
       )
     )
 

--- a/R/internal.R
+++ b/R/internal.R
@@ -806,6 +806,73 @@ gly_annotation <- function(structure, coor) {
   return(struc_annot_coor)
 }
 
+#' Map the coordinate of substituent annotation text
+#'
+#' @param structure an igraph object
+#' @param coor a matrix
+#' @param orient glycan drawing orientation
+#'
+#' @returns dataframe of substituent annotation and coordinate
+#' @noRd
+substituent_annotation <- function(structure, coor, orient) {
+  sub <- igraph::V(structure)$sub
+  if (length(sub) == 0) {
+    return(data.frame(
+      vertice = character(0),
+      annot = character(0),
+      x = numeric(0),
+      y = numeric(0)
+    ))
+  }
+
+  sub[is.na(sub)] <- ""
+  sub_pos <- which(sub != "")
+  if (length(sub_pos) == 0) {
+    return(data.frame(
+      vertice = character(0),
+      annot = character(0),
+      x = numeric(0),
+      y = numeric(0)
+    ))
+  }
+
+  offset <- if (orient == "H") {
+    c(x = 0, y = 0.4)
+  } else {
+    c(x = 0.4, y = 0)
+  }
+
+  data.frame(
+    vertice = as.character(sub_pos),
+    annot = sub[sub_pos],
+    x = as.numeric(coor[sub_pos, "x"] + offset["x"]),
+    y = as.numeric(coor[sub_pos, "y"] + offset["y"]),
+    stringsAsFactors = FALSE
+  )
+}
+
+#' Check whether an annotation can be parsed as plotmath
+#'
+#' @param annot annotation text
+#'
+#' @returns a logical vector
+#' @noRd
+is_parseable_annotation <- function(annot) {
+  purrr::map_lgl(annot, function(x) {
+    !inherits(try(parse(text = x), silent = TRUE), "try-error")
+  })
+}
+
+#' Quote annotation text for plotmath parsing
+#'
+#' @param annot annotation text
+#'
+#' @returns a quoted character vector
+#' @noRd
+quote_annotation <- function(annot) {
+  paste0('"', gsub('"', '\\"', annot, fixed = TRUE), '"')
+}
+
 #' Title Map the coordinate of reducing end annotation and segment
 #'
 #' @param structure an igraph object

--- a/R/internal.R
+++ b/R/internal.R
@@ -844,7 +844,7 @@ substituent_annotation <- function(structure, coor, orient) {
 
   data.frame(
     vertice = as.character(sub_pos),
-    annot = sub[sub_pos],
+    annot = sub("^\\?+", "", sub[sub_pos]),
     x = as.numeric(coor[sub_pos, "x"] + offset["x"]),
     y = as.numeric(coor[sub_pos, "y"] + offset["y"]),
     stringsAsFactors = FALSE

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -26,6 +26,32 @@ test_that("draw_cartoon works with linkage hidden", {
   expect_s3_class(plot_no_linkage, "glydraw_cartoon")
 })
 
+test_that("draw_cartoon places substituent annotations by orientation", {
+  structure <- "GalNAc6S(b1-3)GalNAc(a1-"
+
+  h_plot <- draw_cartoon(structure, orient = "H")
+  h_text <- ggplot2::ggplot_build(h_plot)$data[[4]]
+  h_sub <- h_text[grepl("6S", h_text$label), ]
+
+  expect_equal(nrow(h_sub), 1)
+  if (nrow(h_sub) == 1) {
+    expect_equal(h_sub$size, unique(h_text$size))
+    expect_equal(h_sub$x, -1, tolerance = 1e-6)
+    expect_gt(h_sub$y, 0)
+  }
+
+  v_plot <- draw_cartoon(structure, orient = "V")
+  v_text <- ggplot2::ggplot_build(v_plot)$data[[4]]
+  v_sub <- v_text[grepl("6S", v_text$label), ]
+
+  expect_equal(nrow(v_sub), 1)
+  if (nrow(v_sub) == 1) {
+    expect_equal(v_sub$size, unique(v_text$size))
+    expect_gt(v_sub$x, 0)
+    expect_equal(v_sub$y, 1, tolerance = 1e-6)
+  }
+})
+
 test_that("draw_cartoon works with reducing-end O-Fuc glycans", {
   glycans <- c(
     "Fuc(a1-",

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -52,6 +52,16 @@ test_that("draw_cartoon places substituent annotations by orientation", {
   }
 })
 
+test_that("draw_cartoon ignores unknown substituent linkage in annotation", {
+  structure <- "GalNAc?S(b1-3)GalNAc(a1-"
+
+  plot <- draw_cartoon(structure)
+  labels <- ggplot2::ggplot_build(plot)$data[[4]]$label
+
+  expect_true(any(labels == "S"))
+  expect_false(any(grepl("?", labels, fixed = TRUE)))
+})
+
 test_that("draw_cartoon works with reducing-end O-Fuc glycans", {
   glycans <- c(
     "Fuc(a1-",


### PR DESCRIPTION
## Summary
- Render substituent annotations with the same text size as linkage labels.
- Place substituent text above residues in `H` orientation and to the right in `V` orientation.
- Strip unknown substituent linkage markers such as `?S` so they render as `S` instead of `?(S)`.
- Add regression coverage for both orientation placement and unknown-linkage normalization.

## Testing
- Added focused unit tests for substituent placement and `?S` handling.
- Ran package documentation and the full test suite locally; formatting and whitespace checks passed.

Closes #13