### PR TITLE
Improve export_cartoons output handling

### DIFF
--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -202,7 +202,8 @@ save_cartoon <- function(cartoon, file, dpi = 300) {
 #' @param x A [glyexp::experiment()], a [glyrepr::glycan_structure()] vector,
 #'   or a character vector of any glycan structure text nomenclatures
 #'   supported by [glyparse::auto_parse()].
-#' @param dirname Directory name to save the cartoons.
+#' @param dirname Directory name to save the cartoons. If it does not exist,
+#'   it is created.
 #' @param file_ext File extention supported by [ggplot2::ggsave()]. Defaults to "png".
 #' @param dpi Dots per inch. Defaults to 300.
 #' @inheritParams draw_cartoon
@@ -306,7 +307,7 @@ export_cartoons.glyrepr_structure <- function(
   orient
 ) {
   cli::cli_alert_info("Exporting {.val {length(glycans)}} glycan cartoons.")
-  checkmate::assert_directory_exists(dirname)
+  fs::dir_create(dirname)
   glycan_list <- purrr::map(seq_along(glycans), ~ glycans[[.x]])
   cartoons <- purrr::map(
     glycan_list,

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -197,7 +197,9 @@ save_cartoon <- function(cartoon, file, dpi = 300) {
 #'
 #' This function calls [draw_cartoon()] on each glycan structure in `x`,
 #' then calls [save_cartoon()] to save a figure for each of them.
-#' IUPAC-condensed nonmenclatures are used as file names.
+#' IUPAC-condensed nonmenclatures are used as file names. If `x` is a named
+#' character vector or named [glyrepr::glycan_structure()] vector, the vector
+#' names are used as file names.
 #'
 #' @param x A [glyexp::experiment()], a [glyrepr::glycan_structure()] vector,
 #'   or a character vector of any glycan structure text nomenclatures
@@ -317,11 +319,24 @@ export_cartoons.glyrepr_structure <- function(
   )
   filenames <- fs::path(
     dirname,
-    .sanitize_export_filenames(glycans),
+    .sanitize_export_filenames(.export_filename_labels(glycans)),
     ext = file_ext
   )
   purrr::walk2(cartoons, filenames, save_cartoon, dpi = dpi)
   invisible(cartoons)
+}
+
+#' Select filename labels for exported cartoons
+#'
+#' @param glycans A vector of glycan structures.
+#' @return A vector of labels for output filenames.
+#' @noRd
+.export_filename_labels <- function(glycans) {
+  if (is.null(names(glycans))) {
+    glycans
+  } else {
+    names(glycans)
+  }
 }
 
 .sanitize_export_filenames <- function(glycans) {

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -197,7 +197,7 @@ save_cartoon <- function(cartoon, file, dpi = 300) {
 #'
 #' This function calls [draw_cartoon()] on each glycan structure in `x`,
 #' then calls [save_cartoon()] to save a figure for each of them.
-#' IUPAC-condensed nonmenclatures are used as file names. If `x` is a named
+#' IUPAC-condensed nomenclatures are used as file names. If `x` is a named
 #' character vector or named [glyrepr::glycan_structure()] vector, the vector
 #' names are used as file names.
 #'
@@ -206,7 +206,7 @@ save_cartoon <- function(cartoon, file, dpi = 300) {
 #'   supported by [glyparse::auto_parse()].
 #' @param dirname Directory name to save the cartoons. If it does not exist,
 #'   it is created.
-#' @param file_ext File extention supported by [ggplot2::ggsave()]. Defaults to "png".
+#' @param file_ext File extension supported by [ggplot2::ggsave()]. Defaults to "png".
 #' @param dpi Dots per inch. Defaults to 300.
 #' @inheritParams draw_cartoon
 #'
@@ -335,7 +335,11 @@ export_cartoons.glyrepr_structure <- function(
   if (is.null(names(glycans))) {
     glycans
   } else {
-    names(glycans)
+    labels <- as.character(glycans)
+    glycan_names <- names(glycans)
+    has_name <- !is.na(glycan_names) & nzchar(glycan_names)
+    labels[has_name] <- glycan_names[has_name]
+    labels
   }
 }
 

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -36,7 +36,9 @@ The function returns the list of cartoons implicitly.
 \description{
 This function calls \code{\link[=draw_cartoon]{draw_cartoon()}} on each glycan structure in \code{x},
 then calls \code{\link[=save_cartoon]{save_cartoon()}} to save a figure for each of them.
-IUPAC-condensed nonmenclatures are used as file names.
+IUPAC-condensed nonmenclatures are used as file names. If \code{x} is a named
+character vector or named \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector, the vector
+names are used as file names.
 }
 \examples{
 \dontrun{

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -18,7 +18,8 @@ export_cartoons(
 or a character vector of any glycan structure text nomenclatures
 supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.}
 
-\item{dirname}{Directory name to save the cartoons.}
+\item{dirname}{Directory name to save the cartoons. If it does not exist,
+it is created.}
 
 \item{file_ext}{File extention supported by \code{\link[ggplot2:ggsave]{ggplot2::ggsave()}}. Defaults to "png".}
 

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -21,7 +21,7 @@ supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.}
 \item{dirname}{Directory name to save the cartoons. If it does not exist,
 it is created.}
 
-\item{file_ext}{File extention supported by \code{\link[ggplot2:ggsave]{ggplot2::ggsave()}}. Defaults to "png".}
+\item{file_ext}{File extension supported by \code{\link[ggplot2:ggsave]{ggplot2::ggsave()}}. Defaults to "png".}
 
 \item{dpi}{Dots per inch. Defaults to 300.}
 
@@ -36,7 +36,7 @@ The function returns the list of cartoons implicitly.
 \description{
 This function calls \code{\link[=draw_cartoon]{draw_cartoon()}} on each glycan structure in \code{x},
 then calls \code{\link[=save_cartoon]{save_cartoon()}} to save a figure for each of them.
-IUPAC-condensed nonmenclatures are used as file names. If \code{x} is a named
+IUPAC-condensed nomenclatures are used as file names. If \code{x} is a named
 character vector or named \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector, the vector
 names are used as file names.
 }

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -110,6 +110,22 @@ test_that("export_cartoons works with character vector input", {
   expect_length(files, 2)
 })
 
+test_that("export_cartoons uses character vector names as filenames", {
+  glycans <- c(
+    core = "Man(a1-3)Man(b1-4)GlcNAc(b1-",
+    antenna = "Gal(b1-4)GlcNAc(b1-"
+  )
+  temp_dir <- tempfile()
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+  fs::dir_create(temp_dir)
+
+  suppressMessages(result <- export_cartoons(glycans, temp_dir, dpi = 72))
+
+  expect_length(result, 2)
+  files <- fs::dir_ls(temp_dir, glob = "*.png")
+  expect_setequal(fs::path_file(files), c("core.png", "antenna.png"))
+})
+
 test_that("export_cartoons removes duplicates for character input", {
   glycans <- c(
     "Man(a1-3)Man(b1-4)GlcNAc(b1-",
@@ -143,6 +159,23 @@ test_that("export_cartoons works with glyrepr_structure input", {
   expect_length(result, 2)
   files <- fs::dir_ls(temp_dir, glob = "*.png")
   expect_length(files, 2)
+})
+
+test_that("export_cartoons uses glyrepr_structure names as filenames", {
+  skip_if_not_installed("glyrepr")
+  structures <- glyrepr::as_glycan_structure(c(
+    core = "Man(a1-3)Man(b1-4)GlcNAc(b1-",
+    antenna = "Gal(b1-4)GlcNAc(b1-"
+  ))
+  temp_dir <- tempfile()
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+  fs::dir_create(temp_dir)
+
+  suppressMessages(result <- export_cartoons(structures, temp_dir, dpi = 72))
+
+  expect_length(result, 2)
+  files <- fs::dir_ls(temp_dir, glob = "*.png")
+  expect_setequal(fs::path_file(files), c("core.png", "antenna.png"))
 })
 
 test_that("export_cartoons removes duplicates for glyrepr_structure input", {

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -126,6 +126,25 @@ test_that("export_cartoons uses character vector names as filenames", {
   expect_setequal(fs::path_file(files), c("core.png", "antenna.png"))
 })
 
+test_that("export_cartoons falls back to structure filenames for empty names", {
+  glycans <- c(
+    core = "Man(a1-3)Man(b1-4)GlcNAc(b1-",
+    "Gal(b1-4)GlcNAc(b1-"
+  )
+  temp_dir <- tempfile()
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+  fs::dir_create(temp_dir)
+
+  suppressMessages(result <- export_cartoons(glycans, temp_dir, dpi = 72))
+
+  expect_length(result, 2)
+  files <- fs::dir_ls(temp_dir, glob = "*.png")
+  expect_setequal(
+    fs::path_file(files),
+    c("core.png", "Gal(b1-4)GlcNAc(b1-.png")
+  )
+})
+
 test_that("export_cartoons removes duplicates for character input", {
   glycans <- c(
     "Man(a1-3)Man(b1-4)GlcNAc(b1-",
@@ -241,7 +260,7 @@ test_that("export_cartoons errors when glycan_structure column is missing", {
 
 test_that("export_cartoons creates non-existent directory", {
   glycans <- "Man(a1-3)Man(b1-4)GlcNAc(b1-"
-  non_existent_dir <- file.path(tempdir(), "non_existent_dir_12345")
+  non_existent_dir <- tempfile(pattern = "non_existent_dir_")
   on.exit(unlink(non_existent_dir, recursive = TRUE), add = TRUE)
 
   suppressMessages(

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -206,14 +206,19 @@ test_that("export_cartoons errors when glycan_structure column is missing", {
   )
 })
 
-test_that("export_cartoons errors for non-existent directory", {
+test_that("export_cartoons creates non-existent directory", {
   glycans <- "Man(a1-3)Man(b1-4)GlcNAc(b1-"
   non_existent_dir <- file.path(tempdir(), "non_existent_dir_12345")
+  on.exit(unlink(non_existent_dir, recursive = TRUE), add = TRUE)
 
-  expect_error(
-    export_cartoons(glycans, non_existent_dir),
-    "Assertion on 'dirname' failed"
+  suppressMessages(
+    result <- export_cartoons(glycans, non_existent_dir, dpi = 72)
   )
+
+  expect_length(result, 1)
+  expect_true(fs::dir_exists(non_existent_dir))
+  files <- fs::dir_ls(non_existent_dir, glob = "*.png")
+  expect_length(files, 1)
 })
 
 test_that("export_cartoons works with jpeg extension", {


### PR DESCRIPTION
## Summary

This PR updates `export_cartoons()` in two ways:

1. Creates the target output directory when `dirname` does not already exist.
2. Uses names from named character vectors or named `glyrepr_structure` vectors as exported filenames.

Unnamed vector inputs and experiment inputs keep the existing IUPAC-based filename behavior. Filename sanitization still runs on the selected labels before saving files.

## Validation

- `Rscript -e 'devtools::test()'` - 44 passed, 0 failed
- `git diff --check main...HEAD`