### PR TITLE
fix: place a1-6 core Fuc up and a1-3 core Fuc down

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Minor improvements and bug fixes
 
 * Fix overlapping linkage annotations for some glycans. (#21)
-* Fix overlapping a1-3 and a1-6 core Fucose residues. (#20)
+* Fix overlapping a1-3 and a1-6 core Fucose residues. (#23)
 
 # glydraw 0.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Minor improvements and bug fixes
 
 * Fix overlapping linkage annotations for some glycans. (#21)
+* Fix overlapping a1-3 and a1-6 core Fucose residues. (#20)
 
 # glydraw 0.4.1
 

--- a/R/internal.R
+++ b/R/internal.R
@@ -357,22 +357,20 @@ fuc_out_degree <- function(structure, ver, coor) {
   return(c(num, pos))
 }
 
-#' Title Process the y-Coordinate of 'Fucose' Vertex
+#' Title Process the y-Coordinate of 'Fucose' Vertices
 #'
 #' @param structure an igraph object
-#' @param fuc_pos an integer
+#' @param fuc_pos An integer vector of 'Fucose' vertex indices.
 #'
-#' @returns the Offset of Specified 'Fucose' Vertex
+#' @returns A numeric vector of vertical offsets for the specified vertices.
 #'
-#' @examples fuc_offset(structure, 1)
+#' @examples fuc_offset(structure, c(1, 2))
 #' @noRd
 fuc_offset <- function(structure, fuc_pos) {
   linkage_str <- igraph::E(structure)[fuc_pos]$linkage
-  linkage_pos <- strsplit(linkage_str, '-')[[1]][2]
-  offset <- 0.99
-  if (linkage_pos %in% c('2', '3')) {
-    offset <- -0.99
-  }
+  linkage_pos <- purrr::map_chr(strsplit(linkage_str, '-'), 2)
+  offset <- rep(0.99, length(linkage_pos))
+  offset[linkage_pos %in% c('2', '3')] <- -0.99
   return(offset)
 }
 

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -104,6 +104,18 @@ test_that("reducing-end Fuc keeps the regular Fuc orientation", {
   expect_equal(unname(coor_cal(graph)[2, "x"]), 0)
 })
 
+test_that("draw_cartoon places a1-6 core Fuc up and a1-3 core Fuc down", {
+  structure <- "Fuc(a1-3)[Fuc(a1-6)]GlcNAc(b1-4)GlcNAc(b1-"
+
+  plot <- draw_cartoon(structure)
+  segments <- ggplot2::ggplot_build(plot)$data[[1]]
+  fuc_segments <- segments[segments$x == segments$xend, ]
+
+  expect_equal(nrow(fuc_segments), 2)
+  expect_gt(max(fuc_segments$yend), 0.5)
+  expect_lt(min(fuc_segments$yend), -0.5)
+})
+
 test_that("save_cartoon saves file correctly", {
   structure <- "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
   cartoon <- draw_cartoon(structure)


### PR DESCRIPTION
Closes #20.

Vectorizes fuc_offset() so each core Fucose gets its own vertical offset based on its linkage. a1-6 Fuc now points up and a1-3 Fuc points down, preventing overlap when both are present on the same core GlcNAc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)