### PR TITLE
fix: orient reducing end annotation line vertically when orient = 'V'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Minor improvements and bug fixes
 
+* Orient reducing end annotation line vertically when `orient = "V"`. (#24)
 * Fix overlapping linkage annotations for some glycans. (#21)
 * Fix overlapping a1-3 and a1-6 core Fucose residues. (#23)
 

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -64,7 +64,7 @@ draw_cartoon <- function(
     gly_annotation(structure, coor),
     substituent_annotation(structure, coor, orient)
   )
-  reducing_info <- reducing_end_annotation(structure, coor)
+  reducing_info <- reducing_end_annotation(structure, coor, orient)
   struc_annotation <- dplyr::bind_rows(
     struc_annotation,
     reducing_info$annotation

--- a/R/internal.R
+++ b/R/internal.R
@@ -1163,12 +1163,14 @@ quote_annotation <- function(annot) {
 #'
 #' @param structure an igraph object
 #' @param coor a matrix
+#' @param orient glycan drawing orientation, "H" or "V"
 #'
 #' @returns list of reducing end annotation and segment
 #'
-#' @examples reducing_end_annotation(structure, coor)
+#' @examples reducing_end_annotation(structure, coor, orient)
 #' @noRd
-reducing_end_annotation <- function(structure, coor) {
+reducing_end_annotation <- function(structure, coor, orient = c("H", "V")) {
+  orient <- rlang::arg_match(orient)
   anomer <- igraph::graph_attr(structure, "anomer")
   if (length(anomer) == 0 || is.na(anomer) || anomer == "") {
     return(list(
@@ -1198,7 +1200,12 @@ reducing_end_annotation <- function(structure, coor) {
   root_coor <- c(x = as.numeric(coor[root, 1]), y = as.numeric(coor[root, 2]))
   line_length <- 0.6
   label_offset <- 0.2
-  line_end <- root_coor + c(line_length, 0)
+  line_vec <- if (orient == "H") {
+    c(x = line_length, y = 0)
+  } else {
+    c(x = 0, y = -line_length)
+  }
+  line_end <- root_coor + line_vec
   rotate_angle <- 1 / 10 * pi
   rotate_matrix <- matrix(
     c(
@@ -1210,7 +1217,11 @@ reducing_end_annotation <- function(structure, coor) {
     ncol = 2,
     byrow = TRUE
   )
-  label_vec <- c(line_length + label_offset, 0)
+  label_vec <- if (orient == "H") {
+    c(x = line_length + label_offset, y = 0)
+  } else {
+    c(x = 0, y = -(line_length + label_offset))
+  }
   annot_loc <- 0.6 * rotate_matrix %*% matrix(label_vec, ncol = 1)
   annot_coor <- root_coor + as.vector(annot_loc)
   list(

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -19,6 +19,26 @@ test_that("draw_cartoon works with vertical orientation", {
   expect_s3_class(v_plot, "ggplot")
 })
 
+test_that("draw_cartoon orients reducing end annotation line by orientation", {
+  structure <- "Gal(b1-3)GalNAc(a1-"
+
+  h_plot <- draw_cartoon(structure, orient = "H")
+  h_segments <- ggplot2::ggplot_build(h_plot)$data[[1]]
+  h_reducing <- tail(h_segments, 1)
+  expect_equal(h_reducing$x, 0, tolerance = 1e-6)
+  expect_equal(h_reducing$y, 0, tolerance = 1e-6)
+  expect_equal(h_reducing$xend, 0.6, tolerance = 1e-6)
+  expect_equal(h_reducing$yend, 0, tolerance = 1e-6)
+
+  v_plot <- draw_cartoon(structure, orient = "V")
+  v_segments <- ggplot2::ggplot_build(v_plot)$data[[1]]
+  v_reducing <- tail(v_segments, 1)
+  expect_equal(v_reducing$x, 0, tolerance = 1e-6)
+  expect_equal(v_reducing$y, 0, tolerance = 1e-6)
+  expect_equal(v_reducing$xend, 0, tolerance = 1e-6)
+  expect_equal(v_reducing$yend, -0.6, tolerance = 1e-6)
+})
+
 test_that("draw_cartoon works with linkage hidden", {
   structure <- "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
 


### PR DESCRIPTION
Closes #22.

When `orient = "V"`, the reducing end annotation line and label are now oriented vertically to match the rotated glycan drawing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)