### PR TITLE
Improve fucose subtree orientation in glydraw cartoons

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -201,7 +201,7 @@ coor_initialization <- function(structure) {
     if (
       igraph::V(structure)[[i]]$mono == 'Fuc' && !.is_reducing_end(structure, i)
     ) {
-      coor[i, 'x'] <- coor[i, 'x'] + 1
+      coor <- offset_chil_axis(structure, i, coor, "x", 1)
     }
   }
   return(coor)
@@ -244,9 +244,53 @@ chil_coor <- function(structure, ver) {
 #' @examples offset_chil_coor(structure, 3, coor, 0.5)
 #' @noRd
 offset_chil_coor <- function(structure, ver, coor, offset) {
+  offset_chil_axis(structure, ver, coor, "y", offset)
+}
+
+#' Offset one coordinate axis for a vertex subtree.
+#'
+#' @param structure an igraph object
+#' @param ver an integer vertex index
+#' @param coor a coordinate matrix
+#' @param axis coordinate axis to offset
+#' @param offset a numeric offset
+#'
+#' @returns offset coordinate matrix
+#' @noRd
+offset_chil_axis <- function(structure, ver, coor, axis, offset) {
   vers <- chil_coor(structure, ver)
-  coor[vers, 'y'] <- coor[vers, 'y'] + offset
+  coor[vers, axis] <- coor[vers, axis] + offset
   return(coor)
+}
+
+#' Rotate a Fuc subtree into the Fuc branch direction.
+#'
+#' @param structure an igraph object
+#' @param fuc_pos an integer Fuc vertex index
+#' @param coor a coordinate matrix
+#' @param branch_offset a numeric vertical offset for the Fuc branch
+#'
+#' @returns coordinate matrix with the Fuc descendants rotated
+#' @noRd
+orient_fucose_subtree <- function(structure, fuc_pos, coor, branch_offset) {
+  direction <- sign(branch_offset)
+  if (!is.finite(direction) || direction == 0) {
+    return(coor)
+  }
+
+  descendants <- setdiff(as.integer(chil_coor(structure, fuc_pos)), fuc_pos)
+  if (length(descendants) == 0) {
+    return(coor)
+  }
+
+  fuc_x <- coor[fuc_pos, 'x']
+  fuc_y <- coor[fuc_pos, 'y']
+  relative_x <- coor[descendants, 'x'] - fuc_x
+  relative_y <- coor[descendants, 'y'] - fuc_y
+
+  coor[descendants, 'x'] <- fuc_x + relative_y
+  coor[descendants, 'y'] <- fuc_y - relative_x * direction
+  coor
 }
 
 #' Title Calculate the Amount and Sequence Number of Vertices that Out-degree >= 2 along the Path
@@ -625,7 +669,15 @@ coor_cal <- function(structure) {
       neigh_pos <- igraph::neighbors(structure, i)
       fuc_pos <- neigh_pos[which(neigh_pos$mono == 'Fuc')]
       fuc_list <- c(fuc_list, fuc_pos)
-      coor[fuc_pos, 'y'] <- coor[fuc_pos, 'y'] + fuc_offset(structure, fuc_pos)
+      coor <- purrr::reduce2(
+        as.integer(fuc_pos),
+        fuc_offset(structure, fuc_pos),
+        function(coor_acc, fuc_vertex, offset) {
+          coor_acc <- offset_chil_coor(structure, fuc_vertex, coor_acc, offset)
+          orient_fucose_subtree(structure, fuc_vertex, coor_acc, offset)
+        },
+        .init = coor
+      )
     }
   }
   temp_coor <- coor

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -136,6 +136,26 @@ test_that("draw_cartoon places a1-6 core Fuc up and a1-3 core Fuc down", {
   expect_lt(min(fuc_segments$yend), -0.5)
 })
 
+test_that("draw_cartoon keeps elongated Fuc branches together", {
+  structure <- .ensure_one_structure(
+    paste0(
+      "WURCS=2.0/6,7,6/",
+      "[a2122h-1a_1-5_2*NCC/3=O][a1221m-1a_1-5]",
+      "[a2122h-1b_1-5_2*NCC/3=O][a2112h-1b_1-5]",
+      "[a1122h-1b_1-5][a1122h-1a_1-5]/",
+      "1-2-3-2-4-5-6/",
+      "a3-b1_a4-c1_c3-d1_c4-f1_d4-e1_f3-g1"
+    )
+  )
+  graph <- glyrepr::get_structure_graphs(structure, return_list = FALSE)
+  coor <- coor_cal(graph)
+
+  expect_equal(igraph::V(graph)$mono[c(1, 2, 3)], c("Gal", "Fuc", "Man"))
+  expect_equal(unname(coor[1, "x"]), unname(coor[2, "x"]))
+  expect_lt(unname(coor[1, "y"]), unname(coor[2, "y"]))
+  expect_false(identical(unname(coor[1, ]), unname(coor[3, ])))
+})
+
 test_that("save_cartoon saves file correctly", {
   structure <- "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
   cartoon <- draw_cartoon(structure)


### PR DESCRIPTION
## Summary
- Add axis-specific coordinate offsets to support subtree repositioning on either axis
- Rotate elongated Fuc subtrees so descendant branches stay grouped with the branch direction
- Cover the new layout behavior with a regression test for elongated Fuc branches

## Testing
- Not run (not requested)

Closes #19