### PR TITLE
Refine cartoon branch spacing for nested sibling layouts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,10 @@
 
 ## Minor improvements and bug fixes
 
-* Orient reducing end annotation line vertically when `orient = "V"`. (#24)
 * Fix overlapping linkage annotations for some glycans. (#21)
 * Fix overlapping a1-3 and a1-6 core Fucose residues. (#23)
+* Orient reducing end annotation line vertically when `orient = "V"`. (#24)
+* Refine branch spacing for some glycans. (#26)
 
 # glydraw 0.4.1
 

--- a/R/internal.R
+++ b/R/internal.R
@@ -418,6 +418,57 @@ fuc_offset <- function(structure, fuc_pos) {
   return(offset)
 }
 
+#' Check whether an ancestor branch needs extra spacing.
+#'
+#' @param structure an igraph object
+#' @param ver the descendant branch vertex being processed
+#' @param ancestor an ancestor branch vertex
+#' @param neighbor_pos child vertices of `ancestor`
+#'
+#' @returns A logical scalar.
+#' @noRd
+has_deep_sibling_branch <- function(
+  structure,
+  ver,
+  ancestor,
+  neighbor_pos
+) {
+  path <- igraph::shortest_paths(
+    structure,
+    ancestor,
+    ver,
+    mode = "out"
+  )$vpath[[1]]
+  path <- as.integer(path)
+  if (length(path) < 2) {
+    return(TRUE)
+  }
+
+  path_child <- path[2]
+  sibling_pos <- setdiff(as.integer(neighbor_pos), path_child)
+  if (length(sibling_pos) == 0) {
+    return(TRUE)
+  }
+
+  branch_child_pos <- as.integer(igraph::neighbors(
+    structure,
+    ver,
+    mode = "out"
+  ))
+  if (length(branch_child_pos) == 0) {
+    return(FALSE)
+  }
+
+  depth <- igraph::distances(structure)[length(structure), ]
+  path_depth <- max(depth[branch_child_pos])
+  sibling_depth <- purrr::map_dbl(
+    sibling_pos,
+    ~ max(depth[chil_coor(structure, .x)])
+  )
+
+  any(sibling_depth >= path_depth)
+}
+
 #' Sorting the linkage locations of neighbor vertices
 #'
 #' @param structure an igraph object
@@ -517,22 +568,24 @@ process_multiple_branches <- function(coor, structure, ver) {
     if (length(arrange_neigh_pos) == 2) {
       # Different number of ver's neighbor leads to different offset rule.
       # (3-num_neigh) means when the number of ver's neighbor=3, value=0; 2->1.
-      coor <- offset_chil_coor(
-        structure,
-        arrange_neigh_pos[1],
-        coor,
-        1 /
-          (2**(num - j + (3 - num_neigh))) +
-          0.25 * mid_pos(structure, coor, ver, pos) * (pos != pos_max)
-      )
-      coor <- offset_chil_coor(
-        structure,
-        arrange_neigh_pos[2],
-        coor,
-        -1 /
-          (2**(num - j + (3 - num_neigh))) -
-          0.25 * mid_pos(structure, coor, ver, pos) * (pos != pos_max)
-      )
+      if (has_deep_sibling_branch(structure, ver, pos, arrange_neigh_pos)) {
+        coor <- offset_chil_coor(
+          structure,
+          arrange_neigh_pos[1],
+          coor,
+          1 /
+            (2**(num - j + (3 - num_neigh))) +
+            0.25 * mid_pos(structure, coor, ver, pos) * (pos != pos_max)
+        )
+        coor <- offset_chil_coor(
+          structure,
+          arrange_neigh_pos[2],
+          coor,
+          -1 /
+            (2**(num - j + (3 - num_neigh))) -
+            0.25 * mid_pos(structure, coor, ver, pos) * (pos != pos_max)
+        )
+      }
     } else if (length(arrange_neigh_pos) == 3 && chil_in_middle) {
       # For neighbors=3 vertex, the offset should not be consistent.
       # Only offset the neighbor vertex included in the path along the specified vertex to start vertex.

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -156,6 +156,71 @@ test_that("draw_cartoon keeps elongated Fuc branches together", {
   expect_false(identical(unname(coor[1, ]), unname(coor[3, ])))
 })
 
+test_that("draw_cartoon avoids widening nested branches next to leaf siblings", {
+  short_structure <- .ensure_one_structure(
+    "Man(a1-3)[Man(a1-6)]Man(a1-6)[Man(a1-3)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
+  )
+  short_graph <- glyrepr::get_structure_graphs(
+    short_structure,
+    return_list = FALSE
+  )
+  short_coor <- coor_cal(short_graph)
+
+  terminal_distance <- abs(short_coor[1, "y"] - short_coor[2, "y"])
+  branch_distance <- abs(short_coor[3, "y"] - short_coor[4, "y"])
+  expect_equal(branch_distance, terminal_distance)
+
+  elongated_structure <- .ensure_one_structure(
+    "Man(a1-3)[Man(a1-6)]Man(a1-6)[Man(a1-2)Man(a1-3)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
+  )
+  elongated_graph <- glyrepr::get_structure_graphs(
+    elongated_structure,
+    return_list = FALSE
+  )
+  elongated_coor <- coor_cal(elongated_graph)
+  outer_man <- which(
+    igraph::V(elongated_graph)$mono == "Man" &
+      elongated_coor[, "x"] == min(elongated_coor[, "x"])
+  )
+  outer_y <- sort(elongated_coor[outer_man, "y"])
+
+  expect_equal(diff(outer_y), rep(1, 2))
+})
+
+test_that("draw_cartoon keeps elongated and leaf sibling branches evenly spaced", {
+  structure <- .ensure_one_structure(
+    "Neu5Ac(a2-3)Gal(b1-3)[Gal(b1-3)GlcNAc(b1-3)[Gal(b1-4)GlcNAc(b1-6)]Gal(b1-4)GlcNAc(b1-6)]GalNAc(a1-"
+  )
+  graph <- glyrepr::get_structure_graphs(structure, return_list = FALSE)
+  coor <- coor_cal(graph)
+  same_depth <- which(coor[, "x"] == -2)
+  neu5ac <- same_depth[igraph::V(graph)$mono[same_depth] == "Neu5Ac"]
+  rightmost_gal <- same_depth[igraph::V(graph)$mono[same_depth] == "Gal"]
+
+  expect_equal(length(neu5ac), 1)
+  expect_equal(length(rightmost_gal), 1)
+  expect_equal(
+    unname(abs(coor[neu5ac, "y"] - coor[rightmost_gal, "y"])),
+    1
+  )
+})
+
+test_that("draw_cartoon keeps same-depth Man sibling branches evenly spaced", {
+  structure <- .ensure_one_structure(
+    "Man(a1-2)Man(a1-3)[Man(a1-3)[Man(a1-2)Man(a1-6)]Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
+  )
+  graph <- glyrepr::get_structure_graphs(structure, return_list = FALSE)
+  coor <- coor_cal(graph)
+  same_depth_man <- which(
+    igraph::V(graph)$mono == "Man" &
+      coor[, "x"] == -4
+  )
+  same_depth_y <- sort(coor[same_depth_man, "y"])
+
+  expect_equal(length(same_depth_man), 3)
+  expect_equal(diff(same_depth_y), rep(1, 2))
+})
+
 test_that("save_cartoon saves file correctly", {
   structure <- "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
   cartoon <- draw_cartoon(structure)


### PR DESCRIPTION
## Summary
- Add a deeper-sibling spacing check so branch widening only applies when it will not distort nested layouts next to leaf siblings.
- Tighten cartoon coordinate behavior for elongated and same-depth branch cases.
- Add regression tests covering nested branches, mixed-depth siblings, and evenly spaced same-depth Man branches.

## Testing
- Not run (not requested)

Closes #10