### PR TITLE
Redesign glycan coordinate layout algorithm

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -418,57 +418,6 @@ fuc_offset <- function(structure, fuc_pos) {
   return(offset)
 }
 
-#' Check whether an ancestor branch needs extra spacing.
-#'
-#' @param structure an igraph object
-#' @param ver the descendant branch vertex being processed
-#' @param ancestor an ancestor branch vertex
-#' @param neighbor_pos child vertices of `ancestor`
-#'
-#' @returns A logical scalar.
-#' @noRd
-has_deep_sibling_branch <- function(
-  structure,
-  ver,
-  ancestor,
-  neighbor_pos
-) {
-  path <- igraph::shortest_paths(
-    structure,
-    ancestor,
-    ver,
-    mode = "out"
-  )$vpath[[1]]
-  path <- as.integer(path)
-  if (length(path) < 2) {
-    return(TRUE)
-  }
-
-  path_child <- path[2]
-  sibling_pos <- setdiff(as.integer(neighbor_pos), path_child)
-  if (length(sibling_pos) == 0) {
-    return(TRUE)
-  }
-
-  branch_child_pos <- as.integer(igraph::neighbors(
-    structure,
-    ver,
-    mode = "out"
-  ))
-  if (length(branch_child_pos) == 0) {
-    return(FALSE)
-  }
-
-  depth <- igraph::distances(structure)[length(structure), ]
-  path_depth <- max(depth[branch_child_pos])
-  sibling_depth <- purrr::map_dbl(
-    sibling_pos,
-    ~ max(depth[chil_coor(structure, .x)])
-  )
-
-  any(sibling_depth >= path_depth)
-}
-
 #' Sorting the linkage locations of neighbor vertices
 #'
 #' @param structure an igraph object
@@ -568,24 +517,22 @@ process_multiple_branches <- function(coor, structure, ver) {
     if (length(arrange_neigh_pos) == 2) {
       # Different number of ver's neighbor leads to different offset rule.
       # (3-num_neigh) means when the number of ver's neighbor=3, value=0; 2->1.
-      if (has_deep_sibling_branch(structure, ver, pos, arrange_neigh_pos)) {
-        coor <- offset_chil_coor(
-          structure,
-          arrange_neigh_pos[1],
-          coor,
-          1 /
-            (2**(num - j + (3 - num_neigh))) +
-            0.25 * mid_pos(structure, coor, ver, pos) * (pos != pos_max)
-        )
-        coor <- offset_chil_coor(
-          structure,
-          arrange_neigh_pos[2],
-          coor,
-          -1 /
-            (2**(num - j + (3 - num_neigh))) -
-            0.25 * mid_pos(structure, coor, ver, pos) * (pos != pos_max)
-        )
-      }
+      coor <- offset_chil_coor(
+        structure,
+        arrange_neigh_pos[1],
+        coor,
+        1 /
+          (2**(num - j + (3 - num_neigh))) +
+          0.25 * mid_pos(structure, coor, ver, pos) * (pos != pos_max)
+      )
+      coor <- offset_chil_coor(
+        structure,
+        arrange_neigh_pos[2],
+        coor,
+        -1 /
+          (2**(num - j + (3 - num_neigh))) -
+          0.25 * mid_pos(structure, coor, ver, pos) * (pos != pos_max)
+      )
     } else if (length(arrange_neigh_pos) == 3 && chil_in_middle) {
       # For neighbors=3 vertex, the offset should not be consistent.
       # Only offset the neighbor vertex included in the path along the specified vertex to start vertex.
@@ -684,6 +631,236 @@ process_contain_fucose_neighbors <- function(coor, structure, ver) {
   return(coor)
 }
 
+#' Calculate the vertical gap needed between two subtree profiles.
+#'
+#' @param lower_profile a subtree profile data frame
+#' @param upper_profile a subtree profile data frame
+#' @param min_gap minimum vertical gap in a shared column
+#'
+#' @returns minimum shift needed to place `upper_profile` above `lower_profile`
+#' @noRd
+profile_gap <- function(lower_profile, upper_profile, min_gap = 1) {
+  lower_split <- split(lower_profile$y, lower_profile$x)
+  upper_split <- split(upper_profile$y, upper_profile$x)
+  shared_x <- intersect(names(lower_split), names(upper_split))
+  if (length(shared_x) == 0) {
+    return(0)
+  }
+
+  max(purrr::map_dbl(
+    shared_x,
+    \(x) max(lower_split[[x]]) + min_gap - min(upper_split[[x]])
+  ))
+}
+
+#' Shift a compact subtree layout vertically.
+#'
+#' @param layout a compact subtree layout
+#' @param offset vertical offset
+#'
+#' @returns shifted compact subtree layout
+#' @noRd
+shift_compact_layout <- function(layout, offset) {
+  layout$y <- layout$y + offset
+  layout$profile$y <- layout$profile$y + offset
+  layout
+}
+
+#' Pack child subtree layouts as tightly as possible.
+#'
+#' @param layouts ordered child subtree layouts
+#' @param min_gap minimum vertical gap in a shared column
+#'
+#' @returns numeric vector of vertical shifts
+#' @noRd
+pack_child_layouts <- function(layouts, min_gap = 1) {
+  layout_num <- length(layouts)
+  if (layout_num == 0) {
+    return(numeric(0))
+  }
+
+  shifts <- rep(0, layout_num)
+  for (i in seq_len(layout_num)) {
+    if (i == 1) {
+      next
+    }
+
+    shifts[i] <- max(purrr::map_dbl(
+      seq_len(i - 1),
+      \(j) {
+        shifts[j] +
+          profile_gap(
+            layouts[[j]]$profile,
+            layouts[[i]]$profile,
+            min_gap
+          )
+      }
+    ))
+  }
+
+  shifts - mean(range(shifts))
+}
+
+#' Infer whether a child subtree should sit below or above its parent.
+#'
+#' @param rough_offset rough child root offset from the parent
+#' @param shift compacted child root shift from the parent
+#' @param index child index in bottom-to-top order
+#' @param child_num number of children
+#'
+#' @returns -1 for below the parent, 1 for above the parent
+#' @noRd
+child_compaction_direction <- function(
+  rough_offset,
+  shift,
+  index,
+  child_num
+) {
+  direction <- sign(rough_offset)
+  if (!is.finite(direction) || direction == 0) {
+    direction <- sign(shift)
+  }
+  if (!is.finite(direction) || direction == 0) {
+    direction <- ifelse(index <= child_num / 2, -1, 1)
+  }
+  direction
+}
+
+#' Keep child subtrees away from their parent in a shared column.
+#'
+#' @param layouts ordered child subtree layouts
+#' @param shifts child layout shifts
+#' @param rough_offsets rough child root offsets from the parent
+#' @param parent_x parent x coordinate
+#' @param min_gap minimum vertical gap in a shared column
+#'
+#' @returns adjusted child layout shifts
+#' @noRd
+enforce_parent_profile_gap <- function(
+  layouts,
+  shifts,
+  rough_offsets,
+  parent_x,
+  min_gap = 1
+) {
+  layout_num <- length(layouts)
+  if (layout_num == 0) {
+    return(shifts)
+  }
+
+  for (iter in seq_len(layout_num + 1)) {
+    shifted <- purrr::map2(layouts, shifts, shift_compact_layout)
+    changed <- FALSE
+
+    for (i in seq_len(layout_num)) {
+      profile <- shifted[[i]]$profile
+      parent_column_y <- profile$y[profile$x == parent_x]
+      if (length(parent_column_y) == 0) {
+        next
+      }
+
+      direction <- child_compaction_direction(
+        rough_offsets[i],
+        shifts[i],
+        i,
+        layout_num
+      )
+      if (direction < 0) {
+        violation <- max(parent_column_y) + min_gap
+        if (violation > sqrt(.Machine$double.eps)) {
+          shifts[seq_len(i)] <- shifts[seq_len(i)] - violation
+          changed <- TRUE
+        }
+      } else {
+        violation <- min_gap - min(parent_column_y)
+        if (violation > sqrt(.Machine$double.eps)) {
+          shifts[seq(i, layout_num)] <- shifts[seq(i, layout_num)] + violation
+          changed <- TRUE
+        }
+      }
+    }
+
+    if (!changed) {
+      break
+    }
+  }
+
+  shifts
+}
+
+#' Compact a subtree layout while preserving the current branch order.
+#'
+#' @param structure an igraph object
+#' @param ver subtree root vertex
+#' @param coor current coordinate matrix
+#' @param min_gap minimum vertical gap in a shared column
+#'
+#' @returns a compact subtree layout
+#' @noRd
+compact_subtree_layout <- function(structure, ver, coor, min_gap = 1) {
+  child_pos <- as.integer(igraph::neighbors(structure, ver, mode = "out"))
+  vertex_profile <- data.frame(
+    vertex = ver,
+    x = as.numeric(coor[ver, "x"]),
+    y = 0
+  )
+  if (length(child_pos) == 0) {
+    return(list(
+      y = stats::setNames(0, as.character(ver)),
+      profile = vertex_profile
+    ))
+  }
+
+  rough_offsets <- as.numeric(coor[child_pos, "y"] - coor[ver, "y"])
+  child_order <- order(rough_offsets, child_pos)
+  child_pos <- child_pos[child_order]
+  rough_offsets <- rough_offsets[child_order]
+  layouts <- purrr::map(
+    child_pos,
+    \(child) compact_subtree_layout(structure, child, coor, min_gap)
+  )
+  shifts <- pack_child_layouts(layouts, min_gap)
+  shifts <- enforce_parent_profile_gap(
+    layouts,
+    shifts,
+    rough_offsets,
+    parent_x = as.numeric(coor[ver, "x"]),
+    min_gap = min_gap
+  )
+  shifted_layouts <- purrr::map2(layouts, shifts, shift_compact_layout)
+
+  list(
+    y = c(
+      stats::setNames(0, as.character(ver)),
+      unlist(purrr::map(shifted_layouts, "y"))
+    ),
+    profile = dplyr::bind_rows(
+      vertex_profile,
+      purrr::map(shifted_layouts, "profile")
+    )
+  )
+}
+
+#' Compact a complete coordinate matrix after rough layout.
+#'
+#' @param structure an igraph object
+#' @param coor current coordinate matrix
+#' @param min_gap minimum vertical gap in a shared column
+#'
+#' @returns compacted coordinate matrix
+#' @noRd
+compact_coor <- function(structure, coor, min_gap = 1) {
+  layout <- compact_subtree_layout(
+    structure,
+    length(structure),
+    coor,
+    min_gap = min_gap
+  )
+  vertex_pos <- as.integer(names(layout$y))
+  coor[vertex_pos, "y"] <- as.numeric(layout$y)
+  coor
+}
+
 #' Title Process the Coordinate of all Vertices
 #'
 #' @param structure an igraph object
@@ -739,6 +916,7 @@ coor_cal <- function(structure) {
       coor <- process_fucose_branches(coor, structure, i, temp_coor)
     }
   }
+  coor <- compact_coor(structure, coor)
   return(coor)
 }
 

--- a/R/internal.R
+++ b/R/internal.R
@@ -293,114 +293,6 @@ orient_fucose_subtree <- function(structure, fuc_pos, coor, branch_offset) {
   coor
 }
 
-#' Title Calculate the Amount and Sequence Number of Vertices that Out-degree >= 2 along the Path
-#'
-#' @param structure an igraph integer
-#' @param ver the Sequence Number of Vertices
-#'
-#' @returns the number of vertices which neighbors >=2 on the path between vertex and begin vertex
-#'
-#' @examples out_degree(structure, 1)
-#' @noRd
-out_degree <- function(structure, ver) {
-  path_vertex <- igraph::shortest_paths(
-    structure,
-    length(structure),
-    ver
-  )$vpath[[1]]
-  num <- 0
-  pos <- c()
-  for (i in path_vertex) {
-    if (
-      length(igraph::neighbors(structure, i)) >= 2 &&
-        !('Fuc' %in% igraph::neighbors(structure, i)$mono)
-    ) {
-      num <- num + 1
-      pos <- c(pos, i)
-    }
-  }
-  return(c(num, pos))
-}
-
-#' Title Judge whether the Vertex is in the Middle Position of Sub-module
-#'
-#' @param structure an igraph object
-#' @param coor a matrix
-#' @param ver an integer
-#' @param par_ver an integer
-#'
-#' @returns bool
-#'
-#' @examples mid_pos(structure, coor, 1, 3)
-#' @noRd
-mid_pos <- function(structure, coor, ver, par_ver) {
-  pos_mid <- FALSE
-  vers <- chil_coor(structure, par_ver)
-  col_vers <- vers[which(coor[vers, 'x'] == coor[ver, 'x'])]
-  ver_y <- coor[ver, 'y']
-  col_y <- sort(coor[col_vers, 'y'])
-  if (ver_y != min(col_y) && ver_y != max(col_y)) {
-    pos_mid <- TRUE
-  }
-  return(pos_mid)
-}
-
-#' Title Judge whether the 'Fucose' Vertex is in the Middle Position of Sub-module
-#'
-#' @param structure an igraph object
-#' @param coor a matrix
-#' @param ver an integer
-#' @param par_ver an integer
-#'
-#' @returns bool
-#'
-#' @examples fuc_mid_pos(structure, coor, 1, 3)
-#' @noRd
-fuc_mid_pos <- function(structure, coor, ver, par_ver) {
-  vers <- chil_coor(structure, par_ver)
-  col_vers <- vers[which(coor[vers, 'x'] == coor[ver, 'x'])]
-  ver_y <- coor[ver, 'y']
-  col_y <- sort(coor[col_vers, 'y'])
-  ver_index <- which(col_y == ver_y)
-  lag_diff <- abs(col_y - dplyr::lag(col_y)) < 1
-  lead_diff <- abs(col_y - dplyr::lead(col_y)) < 1
-  result <- lag_diff & lead_diff
-  result[is.na(result)] <- FALSE
-  return(result[ver_index])
-}
-
-#' Title Calculate the Amount and Sequence Number of Vertices that Out-degree >= 2 from Specified 'Fucose' vertex along the Path
-#'
-#' @param structure an igraph object
-#' @param ver an integer
-#' @param coor a matrix
-#'
-#' @returns the Amount and Sequence Number of vertices that Out-degree >= 2
-#'
-#' @examples fuc_out_degree(structure, 6, coor)
-#' @noRd
-fuc_out_degree <- function(structure, ver, coor) {
-  path_vertex <- igraph::shortest_paths(
-    structure,
-    length(structure),
-    ver
-  )$vpath[[1]]
-  num <- 0
-  pos <- c()
-  for (i in path_vertex) {
-    if (
-      length(igraph::neighbors(structure, i)) %in%
-        c(2, 3) &&
-        !('Fuc' %in% igraph::neighbors(structure, i)$mono) &&
-        fuc_mid_pos(structure, coor, ver, i)
-    ) {
-      num <- num + 1
-      pos <- c(pos, i)
-    }
-  }
-  return(c(num, pos))
-}
-
 #' Title Process the y-Coordinate of 'Fucose' Vertices
 #'
 #' @param structure an igraph object
@@ -413,8 +305,8 @@ fuc_out_degree <- function(structure, ver, coor) {
 fuc_offset <- function(structure, fuc_pos) {
   linkage_str <- igraph::E(structure)[fuc_pos]$linkage
   linkage_pos <- purrr::map_chr(strsplit(linkage_str, '-'), 2)
-  offset <- rep(0.99, length(linkage_pos))
-  offset[linkage_pos %in% c('2', '3')] <- -0.99
+  offset <- rep(1, length(linkage_pos))
+  offset[linkage_pos %in% c('2', '3')] <- -1
   return(offset)
 }
 
@@ -444,120 +336,6 @@ fuc_offset <- function(structure, fuc_pos) {
   }
 }
 
-#' Title Process the Vertices which Out-degree >=2 along the Path
-#'
-#' @param coor a matrix
-#' @param structure an igraph object
-#' @param fuc_pos an integer
-#' @param temp_coor a matrix
-#'
-#' @returns Processed Coordinate
-#'
-#' @examples process_fucose_branches(coor, structure, 2, temp_coor)
-#' @noRd
-process_fucose_branches <- function(coor, structure, fuc_pos, temp_coor) {
-  num <- fuc_out_degree(structure, fuc_pos, temp_coor)[1]
-  for (i in seq(1, num)) {
-    par_pos <- fuc_out_degree(structure, fuc_pos, temp_coor)[i + 1]
-    arrange_neigh_pos <- .neigh_pos_order(structure, par_pos)
-
-    if (length(arrange_neigh_pos) == 2) {
-      coor <- offset_chil_coor(
-        structure,
-        arrange_neigh_pos[1],
-        coor,
-        1 / (2**(num - i + 1))
-      )
-      coor <- offset_chil_coor(
-        structure,
-        arrange_neigh_pos[2],
-        coor,
-        -1 / (2**(num - i + 1))
-      )
-    } else if (length(arrange_neigh_pos) == 3) {
-      coor <- offset_chil_coor(
-        structure,
-        arrange_neigh_pos[1],
-        coor,
-        1 / (2**(num - i + 1))
-      )
-      coor <- offset_chil_coor(
-        structure,
-        arrange_neigh_pos[3],
-        coor,
-        -1 / (2**(num - i + 1))
-      )
-    }
-  }
-  return(coor)
-}
-
-#' Title Process the Vertices which Out-degree >=2 and more than 2 Father Vertices that Out-degree >= 2 along the Path
-#'
-#' @param coor a matrix
-#' @param structure an igraph object
-#' @param ver an integer
-#'
-#' @returns Processed coordinate
-#'
-#' @examples process_multiple_branches(coor, structure, 3)
-#' @noRd
-process_multiple_branches <- function(coor, structure, ver) {
-  num <- out_degree(structure, ver)[1] # Numbers of vertices which out-degree > 1 (e.g. branch vertices)
-  for (j in seq(1, num - 1)) {
-    # Traverse all branch vertices except for self
-    pos <- out_degree(structure, ver)[j + 1]
-    pos_max <- out_degree(structure, ver)[num] # Position of branch vertices with second largest index
-    arrange_neigh_pos <- .neigh_pos_order(structure, pos)
-    # Judge whether child vertex is in the middle
-    ver_neigh_pos <- igraph::neighbors(structure, ver)
-    num_neigh <- length(ver_neigh_pos)
-    chil_in_middle <- mid_pos(structure, coor, min(ver_neigh_pos), pos) |
-      mid_pos(structure, coor, max(ver_neigh_pos), pos)
-    if (length(arrange_neigh_pos) == 2) {
-      # Different number of ver's neighbor leads to different offset rule.
-      # (3-num_neigh) means when the number of ver's neighbor=3, value=0; 2->1.
-      coor <- offset_chil_coor(
-        structure,
-        arrange_neigh_pos[1],
-        coor,
-        1 /
-          (2**(num - j + (3 - num_neigh))) +
-          0.25 * mid_pos(structure, coor, ver, pos) * (pos != pos_max)
-      )
-      coor <- offset_chil_coor(
-        structure,
-        arrange_neigh_pos[2],
-        coor,
-        -1 /
-          (2**(num - j + (3 - num_neigh))) -
-          0.25 * mid_pos(structure, coor, ver, pos) * (pos != pos_max)
-      )
-    } else if (length(arrange_neigh_pos) == 3 && chil_in_middle) {
-      # For neighbors=3 vertex, the offset should not be consistent.
-      # Only offset the neighbor vertex included in the path along the specified vertex to start vertex.
-      path_vertex <- igraph::shortest_paths(
-        structure,
-        length(structure),
-        ver
-      )$vpath[[1]]
-      offset_index <- which(arrange_neigh_pos %in% path_vertex) # Index of the neighbor to be offset.
-      # (2-offset_index) means when offset_index=1, value=1; 2->0; 3->-1, adjusting offset direction.
-      # (2-num_neigh) means when the number of ver's neighbor=3, value=-1; 2->0.
-      coor <- offset_chil_coor(
-        structure,
-        arrange_neigh_pos[offset_index],
-        coor,
-        (2 - offset_index) *
-          (1 /
-            (2**(num - j + (2 - num_neigh))) +
-            0.25 * mid_pos(structure, coor, ver, pos) * (pos != pos_max))
-      )
-    }
-  }
-  return(coor)
-}
-
 #' Title Process the Vertices which Out-degree =2 along the Path
 #'
 #' @param coor a matrix
@@ -570,15 +348,8 @@ process_multiple_branches <- function(coor, structure, ver) {
 #' @noRd
 process_two_neighbors <- function(coor, structure, ver) {
   arrange_neigh_pos <- .neigh_pos_order(structure, ver)
-  if (out_degree(structure, ver)[1] == 1) {
-    coor <- offset_chil_coor(structure, arrange_neigh_pos[1], coor, 0.5)
-    coor <- offset_chil_coor(structure, arrange_neigh_pos[2], coor, -0.5)
-  } else if (out_degree(structure, ver)[1] >= 2) {
-    # More than 1 branch along the path
-    coor <- offset_chil_coor(structure, arrange_neigh_pos[1], coor, 0.5)
-    coor <- offset_chil_coor(structure, arrange_neigh_pos[2], coor, -0.5)
-    coor <- process_multiple_branches(coor, structure, ver)
-  }
+  coor <- offset_chil_coor(structure, arrange_neigh_pos[1], coor, 0.5)
+  coor <- offset_chil_coor(structure, arrange_neigh_pos[2], coor, -0.5)
   return(coor)
 }
 
@@ -594,15 +365,8 @@ process_two_neighbors <- function(coor, structure, ver) {
 #' @noRd
 process_three_neighbors <- function(coor, structure, ver) {
   arrange_neigh_pos <- .neigh_pos_order(structure, ver)
-  if (out_degree(structure, ver)[1] == 1) {
-    coor <- offset_chil_coor(structure, arrange_neigh_pos[1], coor, 1)
-    coor <- offset_chil_coor(structure, arrange_neigh_pos[3], coor, -1)
-  } else if (out_degree(structure, ver)[1] >= 2) {
-    # More than 1 branch along the path
-    coor <- offset_chil_coor(structure, arrange_neigh_pos[1], coor, 1)
-    coor <- offset_chil_coor(structure, arrange_neigh_pos[3], coor, -1)
-    coor <- process_multiple_branches(coor, structure, ver)
-  }
+  coor <- offset_chil_coor(structure, arrange_neigh_pos[1], coor, 1)
+  coor <- offset_chil_coor(structure, arrange_neigh_pos[3], coor, -1)
   return(coor)
 }
 
@@ -618,16 +382,8 @@ process_three_neighbors <- function(coor, structure, ver) {
 #' @noRd
 process_contain_fucose_neighbors <- function(coor, structure, ver) {
   arrange_other_neigh_pos <- .neigh_pos_order(structure, ver)
-  # Process other vertices coordinate
-  if (out_degree(structure, ver)[1] == 1) {
-    coor <- offset_chil_coor(structure, arrange_other_neigh_pos[1], coor, 0.5)
-    coor <- offset_chil_coor(structure, arrange_other_neigh_pos[2], coor, -0.5)
-  } else if (out_degree(structure, ver)[1] >= 2) {
-    # More than 1 branch along the path
-    coor <- offset_chil_coor(structure, arrange_other_neigh_pos[1], coor, 0.5)
-    coor <- offset_chil_coor(structure, arrange_other_neigh_pos[2], coor, -0.5)
-    coor <- process_multiple_branches(coor, structure, ver)
-  }
+  coor <- offset_chil_coor(structure, arrange_other_neigh_pos[1], coor, 0.5)
+  coor <- offset_chil_coor(structure, arrange_other_neigh_pos[2], coor, -0.5)
   return(coor)
 }
 
@@ -893,12 +649,10 @@ coor_cal <- function(structure) {
       coor <- process_contain_fucose_neighbors(coor, structure, i)
     }
   }
-  fuc_list <- c()
   for (i in structure_length) {
     if ('Fuc' %in% igraph::neighbors(structure, i)$mono) {
       neigh_pos <- igraph::neighbors(structure, i)
       fuc_pos <- neigh_pos[which(neigh_pos$mono == 'Fuc')]
-      fuc_list <- c(fuc_list, fuc_pos)
       coor <- purrr::reduce2(
         as.integer(fuc_pos),
         fuc_offset(structure, fuc_pos),
@@ -908,12 +662,6 @@ coor_cal <- function(structure) {
         },
         .init = coor
       )
-    }
-  }
-  temp_coor <- coor
-  for (i in fuc_list) {
-    if (fuc_out_degree(structure, i, temp_coor)[1] >= 1) {
-      coor <- process_fucose_branches(coor, structure, i, temp_coor)
     }
   }
   coor <- compact_coor(structure, coor)
@@ -959,7 +707,7 @@ connect_info <- function(structure, coor) {
 glycoform_info <- function(structure) {
   glycoform <- igraph::V(structure)$mono
   for (i in c(which(glycoform == 'Fuc'))) {
-    if (!.is_reducing_end(structure, i) && fuc_offset(structure, i) == '0.99') {
+    if (!.is_reducing_end(structure, i) && fuc_offset(structure, i) > 0) {
       glycoform[i] <- 'FucUp'
     }
   }

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -188,6 +188,18 @@ test_that("draw_cartoon places a1-6 core Fuc up and a1-3 core Fuc down", {
   expect_lt(min(fuc_segments$yend), -0.5)
 })
 
+test_that("coor_cal keeps same-column residues at least one unit apart", {
+  structure <- .ensure_one_structure(
+    "Fuc(a1-3)[Fuc(a1-6)]GlcNAc(b1-4)GlcNAc(b1-"
+  )
+  graph <- glyrepr::get_structure_graphs(structure, return_list = FALSE)
+  coor <- coor_cal(graph)
+  same_column <- which(coor[, "x"] == -1)
+  same_column_y <- sort(coor[same_column, "y"])
+
+  expect_equal(diff(same_column_y), rep(1, length(same_column_y) - 1))
+})
+
 test_that("draw_cartoon keeps elongated Fuc branches together", {
   structure <- .ensure_one_structure(
     paste0(


### PR DESCRIPTION
## Summary

This PR replaces the empirical branch-expansion corrections in `coor_cal()` with a post-layout subtree compaction pass. The goal is to make the coordinate workflow easier to reason about: the rough layout establishes depth, branch order, and branch direction, then the compactor enforces final same-column spacing and compactness.

## Current coordinate workflow

The glycan drawing workflow now has three clearer phases:

1. **Initial coordinate assignment**
   - `coor_initialization()` places the reducing end at `x = 0` and assigns each residue an `x` coordinate from its graph distance to the reducing end.
   - Non-reducing Fuc residues are shifted one column toward their parent so core/branch Fuc residues share the parent column, matching the expected SNFG-style branch placement.

2. **Rough branch direction seeding**
   - Two-child and three-child branch processors no longer try to solve final spacing.
   - They only seed rough `y` direction using linkage order, so the later compaction pass can preserve the intended bottom-to-top branch order.
   - Fuc still gets an explicit direction seed from linkage position: acceptor positions `2` and `3` go downward, and other Fuc positions go upward.
   - `orient_fucose_subtree()` is retained because it rotates elongated Fuc descendants into the Fuc branch direction rather than merely changing spacing.

3. **Post-layout compaction**
   - `compact_coor()` rebuilds final `y` coordinates from subtree profiles while preserving the rough branch order from phase 2.
   - This final phase is now responsible for same-column separation and compactness.

## Compaction algorithm details

The compactor treats every subtree as a rigid layout plus a profile. A profile records which `y` values are occupied in each `x` column of that subtree.

For each subtree root:

1. Recursively compact all child subtrees first.
2. Sort child subtrees by their rough `y` offset from the parent. This keeps the existing linkage-driven branch order without preserving old empirical spacing distances.
3. Pack sibling subtree profiles from bottom to top.
4. For each pair of already-packed and newly-packed child profiles, compute the minimum vertical shift required so every shared `x` column is separated by at least one unit:

   ```r
   max(lower_y + min_gap - upper_y)
   ```

5. Apply the smallest shift that satisfies all shared-column constraints.
6. Add parent-column constraints so child residues that share the parent `x` column, such as core Fuc, are also at least one unit away from the parent residue.
7. Merge the child profiles with the parent residue and return the compacted subtree upward.

This means final spacing is driven by explicit profile constraints rather than local ad hoc expansion rules. The previous `0.99` Fuc offset is now an exact `1`, and the removed middle-position expansion helpers are no longer needed because compaction owns final spacing.

## Removed empirical expansion rules

The following helpers were removed after verifying that bypassing them produced identical final coordinates for representative core Fuc, elongated Fuc, and nested-branch examples under the new compaction pass:

- `out_degree()`
- `mid_pos()`
- `fuc_mid_pos()`
- `fuc_out_degree()`
- `process_multiple_branches()`
- `process_fucose_branches()`

The branch processors now only seed rough direction and let the compactor determine final distances.

## Validation

- `devtools::document()`
- `devtools::test(filter = "glydraw")`
- `devtools::test()`
- `air format R/internal.R tests/testthat/test-glydraw.R`
- Final full test run in this PR preparation: `PASS 87`, `FAIL 0`, `WARN 0`, `SKIP 0`
