### PR TITLE
Add configurable linewidths for glycan cartoons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 ## New features
 
+* Add the `edge_linewidth` and `node_linewidth` parameters to `draw_cartoon()` and `export_cartoons()` for customizing linkage line and node border widths.
 * Add the `red_end` parameter to `draw_cartoon()` and `export_cartoons()` for custom reducing-end text or a wavy reducing-end annotation. (#31)
 
 ## Minor improvements and bug fixes

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -8,6 +8,10 @@
 #' @param red_end Reducing-end annotation. The default `""` keeps the current
 #'   reducing-end line. Use `"~"` to add a wavy reducing end, or any other
 #'   string to draw that string at the reducing end.
+#' @param edge_linewidth Numeric scalar controlling the linewidth of linkage
+#'   lines. Defaults to the current value, `0.8`.
+#' @param node_linewidth Numeric scalar controlling the linewidth of node
+#'   borders. Defaults to the current value, `0.8`.
 #' @param highlight An integer vector specifying the node indices to highlight.
 #'   This argument is applicable only when `structure` is a [glyrepr::glycan_structure()].
 #'   Note that for a [glyrepr::glycan_structure()], the node indices correspond exactly
@@ -26,8 +30,12 @@ draw_cartoon <- function(
   show_linkage = TRUE,
   orient = c("H", "V"),
   red_end = "",
+  edge_linewidth = 0.8,
+  node_linewidth = 0.8,
   highlight = NULL
 ) {
+  checkmate::assert_number(edge_linewidth, lower = 0)
+  checkmate::assert_number(node_linewidth, lower = 0)
   inputs <- .prepare_cartoon_inputs(structure, highlight, orient, red_end)
   structure <- inputs$structure
   coor <- inputs$coor
@@ -56,7 +64,9 @@ draw_cartoon <- function(
     polygon_coor,
     filled_color,
     annotation_data,
-    show_linkage
+    show_linkage,
+    edge_linewidth,
+    node_linewidth
   )
 }
 
@@ -173,7 +183,9 @@ export_cartoons <- function(
   dpi = 300,
   show_linkage = TRUE,
   orient = c("H", "V"),
-  red_end = ""
+  red_end = "",
+  edge_linewidth = 0.8,
+  node_linewidth = 0.8
 ) {
   UseMethod("export_cartoons")
 }
@@ -186,7 +198,9 @@ export_cartoons.character <- function(
   dpi = 300,
   show_linkage = TRUE,
   orient = c("H", "V"),
-  red_end = ""
+  red_end = "",
+  edge_linewidth = 0.8,
+  node_linewidth = 0.8
 ) {
   glycans <- unique(.as_glycan_structure_input(x))
   .export_cartoon_list(
@@ -196,7 +210,9 @@ export_cartoons.character <- function(
     dpi = dpi,
     show_linkage = show_linkage,
     orient = orient,
-    red_end = red_end
+    red_end = red_end,
+    edge_linewidth = edge_linewidth,
+    node_linewidth = node_linewidth
   )
 }
 
@@ -208,7 +224,9 @@ export_cartoons.glyrepr_structure <- function(
   dpi = 300,
   show_linkage = TRUE,
   orient = c("H", "V"),
-  red_end = ""
+  red_end = "",
+  edge_linewidth = 0.8,
+  node_linewidth = 0.8
 ) {
   glycans <- unique(x)
   .export_cartoon_list(
@@ -218,7 +236,9 @@ export_cartoons.glyrepr_structure <- function(
     dpi = dpi,
     show_linkage = show_linkage,
     orient = orient,
-    red_end = red_end
+    red_end = red_end,
+    edge_linewidth = edge_linewidth,
+    node_linewidth = node_linewidth
   )
 }
 
@@ -231,6 +251,10 @@ export_cartoons.glyrepr_structure <- function(
 #' @param show_linkage Logical scalar passed to `draw_cartoon()`.
 #' @param orient Drawing orientation, either `"H"` or `"V"`.
 #' @param red_end String reducing-end annotation passed to `draw_cartoon()`.
+#' @param edge_linewidth Numeric linkage line width passed to
+#'   `draw_cartoon()`.
+#' @param node_linewidth Numeric node border line width passed to
+#'   `draw_cartoon()`.
 #'
 #' @return A list of `glydraw_cartoon` objects, invisibly. Files are written to
 #'   `dirname` with sanitized labels and extension `file_ext`.
@@ -242,7 +266,9 @@ export_cartoons.glyrepr_structure <- function(
   dpi,
   show_linkage,
   orient,
-  red_end
+  red_end,
+  edge_linewidth,
+  node_linewidth
 ) {
   cli::cli_alert_info("Exporting {.val {length(glycans)}} glycan cartoons.")
   fs::dir_create(dirname)
@@ -252,7 +278,9 @@ export_cartoons.glyrepr_structure <- function(
     draw_cartoon,
     show_linkage = show_linkage,
     orient = orient,
-    red_end = red_end
+    red_end = red_end,
+    edge_linewidth = edge_linewidth,
+    node_linewidth = node_linewidth
   )
   filenames <- fs::path(
     dirname,

--- a/R/internal-cartoon.R
+++ b/R/internal-cartoon.R
@@ -263,6 +263,8 @@
 #' @param annotation_data A list returned by `.cartoon_text_annotation_data()`.
 #' @param show_linkage A logical scalar indicating whether linkage annotations
 #'   should be drawn.
+#' @param edge_linewidth Numeric scalar used for linkage lines.
+#' @param node_linewidth Numeric scalar used for node borders.
 #'
 #' @returns A `glydraw_cartoon` ggplot object with fixed-size metadata
 #'   attributes.
@@ -272,9 +274,17 @@
   polygon_coor,
   filled_color,
   annotation_data,
-  show_linkage
+  show_linkage,
+  edge_linewidth,
+  node_linewidth
 ) {
-  gly_graph <- .cartoon_base_layers(connect_df, polygon_coor, filled_color)
+  gly_graph <- .cartoon_base_layers(
+    connect_df,
+    polygon_coor,
+    filled_color,
+    edge_linewidth,
+    node_linewidth
+  )
   gly_graph <- .add_cartoon_text_layers(
     gly_graph,
     annotation_data,
@@ -282,7 +292,8 @@
   )
   gly_graph <- .add_reducing_end_layers(
     gly_graph,
-    annotation_data$reducing_info
+    annotation_data$reducing_info,
+    edge_linewidth
   )
   .finalize_cartoon_size(gly_graph)
 }
@@ -293,11 +304,19 @@
 #' @param polygon_coor A data frame with polygon vertices, groups, and `alpha`.
 #' @param filled_color A character vector of polygon fill colors, one value per
 #'   row in `polygon_coor`.
+#' @param edge_linewidth Numeric scalar used for linkage lines.
+#' @param node_linewidth Numeric scalar used for node borders.
 #'
 #' @returns A ggplot object containing segment, white mask polygon, colored
 #'   residue polygon, fixed coordinate, and blank theme layers.
 #' @noRd
-.cartoon_base_layers <- function(connect_df, polygon_coor, filled_color) {
+.cartoon_base_layers <- function(
+  connect_df,
+  polygon_coor,
+  filled_color,
+  edge_linewidth,
+  node_linewidth
+) {
   ggplot2::ggplot() +
     ggplot2::geom_segment(
       data = connect_df,
@@ -308,14 +327,14 @@
         yend = .data$end_y
       ),
       alpha = connect_df$transparency,
-      linewidth = 0.8
+      linewidth = edge_linewidth
     ) +
     ggplot2::geom_polygon(
       data = polygon_coor,
       ggplot2::aes(x = .data$point_x, y = .data$point_y, group = .data$group),
       fill = "white",
       color = "white",
-      linewidth = 0.8
+      linewidth = node_linewidth
     ) +
     ggplot2::geom_polygon(
       data = polygon_coor,
@@ -323,7 +342,7 @@
       alpha = polygon_coor$alpha,
       fill = filled_color,
       color = scales::alpha("black", polygon_coor$alpha),
-      linewidth = 0.8
+      linewidth = node_linewidth
     ) +
     ggplot2::coord_fixed(ratio = 1, clip = "off") +
     ggplot2::theme_void() +
@@ -383,17 +402,18 @@
 #'
 #' @param plot A ggplot object.
 #' @param reducing_info A list returned by `.reducing_end_annotation_data()`.
+#' @param edge_linewidth Numeric scalar used for linkage lines.
 #'
 #' @returns A ggplot object with a `geom_path()` wave layer when available and
 #'   a `geom_blank()` bounds layer when bounds are available.
 #' @noRd
-.add_reducing_end_layers <- function(plot, reducing_info) {
+.add_reducing_end_layers <- function(plot, reducing_info, edge_linewidth) {
   if (nrow(reducing_info$wave) > 0) {
     plot <- plot +
       ggplot2::geom_path(
         data = reducing_info$wave,
         ggplot2::aes(x = .data$x, y = .data$y),
-        linewidth = 0.8
+        linewidth = edge_linewidth
       )
   }
   if (nrow(reducing_info$bounds) > 0) {

--- a/man/draw_cartoon.Rd
+++ b/man/draw_cartoon.Rd
@@ -9,6 +9,8 @@ draw_cartoon(
   show_linkage = TRUE,
   orient = c("H", "V"),
   red_end = "",
+  edge_linewidth = 0.8,
+  node_linewidth = 0.8,
   highlight = NULL
 )
 }
@@ -24,6 +26,12 @@ Default is "H"}
 \item{red_end}{Reducing-end annotation. The default \code{""} keeps the current
 reducing-end line. Use \code{"~"} to add a wavy reducing end, or any other
 string to draw that string at the reducing end.}
+
+\item{edge_linewidth}{Numeric scalar controlling the linewidth of linkage
+lines. Defaults to the current value, \code{0.8}.}
+
+\item{node_linewidth}{Numeric scalar controlling the linewidth of node
+borders. Defaults to the current value, \code{0.8}.}
 
 \item{highlight}{An integer vector specifying the node indices to highlight.
 This argument is applicable only when \code{structure} is a \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}}.

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -11,7 +11,9 @@ export_cartoons(
   dpi = 300,
   show_linkage = TRUE,
   orient = c("H", "V"),
-  red_end = ""
+  red_end = "",
+  edge_linewidth = 0.8,
+  node_linewidth = 0.8
 )
 }
 \arguments{
@@ -34,6 +36,12 @@ Default is "H"}
 \item{red_end}{Reducing-end annotation. The default \code{""} keeps the current
 reducing-end line. Use \code{"~"} to add a wavy reducing end, or any other
 string to draw that string at the reducing end.}
+
+\item{edge_linewidth}{Numeric scalar controlling the linewidth of linkage
+lines. Defaults to the current value, \code{0.8}.}
+
+\item{node_linewidth}{Numeric scalar controlling the linewidth of node
+borders. Defaults to the current value, \code{0.8}.}
 }
 \value{
 The function returns the list of cartoons implicitly.

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -23,6 +23,30 @@ test_that("draw_cartoon uses ggplot2 fixed panel sizing", {
   expect_named(attr(plot, "glydraw_size_px"), c("width", "height"))
 })
 
+test_that("draw_cartoon controls edge and node linewidths", {
+  structure <- "Gal(b1-3)GalNAc(a1-"
+
+  default_plot <- draw_cartoon(structure)
+  default_layers <- ggplot2::ggplot_build(default_plot)$data
+
+  expect_equal(unique(default_layers[[1]]$linewidth), 0.8)
+  expect_equal(unique(default_layers[[2]]$linewidth), 0.8)
+  expect_equal(unique(default_layers[[3]]$linewidth), 0.8)
+
+  custom_plot <- draw_cartoon(
+    structure,
+    red_end = "~",
+    edge_linewidth = 1.2,
+    node_linewidth = 0.4
+  )
+  custom_layers <- ggplot2::ggplot_build(custom_plot)$data
+
+  expect_equal(unique(custom_layers[[1]]$linewidth), 1.2)
+  expect_equal(unique(custom_layers[[2]]$linewidth), 0.4)
+  expect_equal(unique(custom_layers[[3]]$linewidth), 0.4)
+  expect_equal(unique(custom_layers[[5]]$linewidth), 1.2)
+})
+
 test_that("print.glydraw_cartoon rasterizes fixed-size cartoon for display", {
   structure <- paste0(
     "Gal(b1-4)GlcNAc(b1-2)[Gal(b1-4)GlcNAc(b1-4)]Man(a1-3)",
@@ -377,6 +401,27 @@ test_that("export_cartoons works with character vector input", {
   expect_length(result, 2)
   files <- fs::dir_ls(temp_dir, glob = "*.png")
   expect_length(files, 2)
+})
+
+test_that("export_cartoons forwards custom linewidths", {
+  glycans <- "Gal(b1-3)GalNAc(a1-"
+  temp_dir <- tempfile()
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+  fs::dir_create(temp_dir)
+
+  suppressMessages(
+    result <- export_cartoons(
+      glycans,
+      temp_dir,
+      dpi = 72,
+      edge_linewidth = 1.1,
+      node_linewidth = 0.3
+    )
+  )
+  layers <- ggplot2::ggplot_build(result[[1]])$data
+
+  expect_equal(unique(layers[[1]]$linewidth), 1.1)
+  expect_equal(unique(layers[[3]]$linewidth), 0.3)
 })
 
 test_that("export_cartoons uses character vector names as filenames", {


### PR DESCRIPTION
## Summary
- Add `edge_linewidth` and `node_linewidth` parameters to `draw_cartoon()` and `export_cartoons()`.
- Thread the new settings through the cartoon rendering helpers so linkage lines, node borders, and reducing-end waves use the requested widths.
- Add coverage for default behavior and custom linewidth forwarding.

## Testing
- Added unit tests for `draw_cartoon()` linewidth control and `export_cartoons()` parameter forwarding.
- Not run (not requested).