### PR TITLE
Add node_size scaling to cartoon rendering

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 ## New features
 
+* Add the `node_size` parameter to `draw_cartoon()` and `export_cartoons()` for scaling residue cartoon sizes.
 * Add the `edge_linewidth` and `node_linewidth` parameters to `draw_cartoon()` and `export_cartoons()` for customizing linkage line and node border widths.
 * Add the `red_end` parameter to `draw_cartoon()` and `export_cartoons()` for custom reducing-end text or a wavy reducing-end annotation. (#31)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 ## New features
 
-* Add the `node_size` parameter to `draw_cartoon()` and `export_cartoons()` for scaling residue cartoon sizes.
+* Add the `node_size` parameter to `draw_cartoon()` and `export_cartoons()` for scaling residue cartoon sizes. Values larger than `2` are rejected because residues overlap.
 * Add the `edge_linewidth` and `node_linewidth` parameters to `draw_cartoon()` and `export_cartoons()` for customizing linkage line and node border widths.
 * Add the `red_end` parameter to `draw_cartoon()` and `export_cartoons()` for custom reducing-end text or a wavy reducing-end annotation. (#31)
 

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -15,7 +15,8 @@
 #' @param node_size Numeric scalar used as a multiplier for the default node
 #'   size. Defaults to `1`, which keeps the current size. Linkage annotations
 #'   are moved farther from larger nodes, and are hidden with a warning when
-#'   `node_size` is too large to leave enough annotation space.
+#'   `node_size` is too large to leave enough annotation space. Values larger
+#'   than `2` are rejected because residues overlap.
 #' @param highlight An integer vector specifying the node indices to highlight.
 #'   This argument is applicable only when `structure` is a [glyrepr::glycan_structure()].
 #'   Note that for a [glyrepr::glycan_structure()], the node indices correspond exactly
@@ -41,7 +42,7 @@ draw_cartoon <- function(
 ) {
   checkmate::assert_number(edge_linewidth, lower = 0)
   checkmate::assert_number(node_linewidth, lower = 0)
-  checkmate::assert_number(node_size, lower = 0)
+  .validate_node_size(node_size)
   inputs <- .prepare_cartoon_inputs(structure, highlight, orient, red_end)
   structure <- inputs$structure
   coor <- inputs$coor
@@ -199,6 +200,7 @@ export_cartoons <- function(
   node_linewidth = 0.8,
   node_size = 1
 ) {
+  .validate_node_size(node_size)
   UseMethod("export_cartoons")
 }
 
@@ -288,6 +290,7 @@ export_cartoons.glyrepr_structure <- function(
   node_linewidth,
   node_size
 ) {
+  .validate_node_size(node_size)
   cli::cli_alert_info("Exporting {.val {length(glycans)}} glycan cartoons.")
   fs::dir_create(dirname)
   glycan_list <- purrr::map(seq_along(glycans), ~ glycans[[.x]])

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -12,6 +12,10 @@
 #'   lines. Defaults to the current value, `0.8`.
 #' @param node_linewidth Numeric scalar controlling the linewidth of node
 #'   borders. Defaults to the current value, `0.8`.
+#' @param node_size Numeric scalar used as a multiplier for the default node
+#'   size. Defaults to `1`, which keeps the current size. Linkage annotations
+#'   are moved farther from larger nodes, and are hidden with a warning when
+#'   `node_size` is too large to leave enough annotation space.
 #' @param highlight An integer vector specifying the node indices to highlight.
 #'   This argument is applicable only when `structure` is a [glyrepr::glycan_structure()].
 #'   Note that for a [glyrepr::glycan_structure()], the node indices correspond exactly
@@ -32,25 +36,32 @@ draw_cartoon <- function(
   red_end = "",
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
+  node_size = 1,
   highlight = NULL
 ) {
   checkmate::assert_number(edge_linewidth, lower = 0)
   checkmate::assert_number(node_linewidth, lower = 0)
+  checkmate::assert_number(node_size, lower = 0)
   inputs <- .prepare_cartoon_inputs(structure, highlight, orient, red_end)
   structure <- inputs$structure
   coor <- inputs$coor
   highlight <- inputs$highlight
   orient <- inputs$orient
+  show_linkage <- .resolve_linkage_visibility(show_linkage, node_size)
 
   gly_list <- .cartoon_residue_data(structure, coor, highlight)
-  polygon_coor <- .residue_polygon_data(gly_list, 0.215)
+  polygon_coor <- .residue_polygon_data(
+    gly_list,
+    .default_node_point_size * node_size
+  )
   filled_color <- glycan_color[as.character(polygon_coor$color)]
   annotation_data <- .cartoon_text_annotation_data(
     structure,
     coor,
     orient,
     red_end,
-    highlight
+    highlight,
+    node_size = node_size
   )
   connect_df <- .cartoon_segment_data(
     structure,
@@ -185,7 +196,8 @@ export_cartoons <- function(
   orient = c("H", "V"),
   red_end = "",
   edge_linewidth = 0.8,
-  node_linewidth = 0.8
+  node_linewidth = 0.8,
+  node_size = 1
 ) {
   UseMethod("export_cartoons")
 }
@@ -200,7 +212,8 @@ export_cartoons.character <- function(
   orient = c("H", "V"),
   red_end = "",
   edge_linewidth = 0.8,
-  node_linewidth = 0.8
+  node_linewidth = 0.8,
+  node_size = 1
 ) {
   glycans <- unique(.as_glycan_structure_input(x))
   .export_cartoon_list(
@@ -212,7 +225,8 @@ export_cartoons.character <- function(
     orient = orient,
     red_end = red_end,
     edge_linewidth = edge_linewidth,
-    node_linewidth = node_linewidth
+    node_linewidth = node_linewidth,
+    node_size = node_size
   )
 }
 
@@ -226,7 +240,8 @@ export_cartoons.glyrepr_structure <- function(
   orient = c("H", "V"),
   red_end = "",
   edge_linewidth = 0.8,
-  node_linewidth = 0.8
+  node_linewidth = 0.8,
+  node_size = 1
 ) {
   glycans <- unique(x)
   .export_cartoon_list(
@@ -238,7 +253,8 @@ export_cartoons.glyrepr_structure <- function(
     orient = orient,
     red_end = red_end,
     edge_linewidth = edge_linewidth,
-    node_linewidth = node_linewidth
+    node_linewidth = node_linewidth,
+    node_size = node_size
   )
 }
 
@@ -255,6 +271,7 @@ export_cartoons.glyrepr_structure <- function(
 #'   `draw_cartoon()`.
 #' @param node_linewidth Numeric node border line width passed to
 #'   `draw_cartoon()`.
+#' @param node_size Numeric node size multiplier passed to `draw_cartoon()`.
 #'
 #' @return A list of `glydraw_cartoon` objects, invisibly. Files are written to
 #'   `dirname` with sanitized labels and extension `file_ext`.
@@ -268,7 +285,8 @@ export_cartoons.glyrepr_structure <- function(
   orient,
   red_end,
   edge_linewidth,
-  node_linewidth
+  node_linewidth,
+  node_size
 ) {
   cli::cli_alert_info("Exporting {.val {length(glycans)}} glycan cartoons.")
   fs::dir_create(dirname)
@@ -280,7 +298,8 @@ export_cartoons.glyrepr_structure <- function(
     orient = orient,
     red_end = red_end,
     edge_linewidth = edge_linewidth,
-    node_linewidth = node_linewidth
+    node_linewidth = node_linewidth,
+    node_size = node_size
   )
   filenames <- fs::path(
     dirname,

--- a/R/internal-annotations.R
+++ b/R/internal-annotations.R
@@ -11,8 +11,8 @@
 #'   child-side linkage label.
 #' @param par_offset Numeric distance from the parent residue center to the
 #'   parent-side linkage label.
-#' @param node_size Numeric node-size multiplier used to push labels away from
-#'   scaled residue polygons.
+#' @param node_size Numeric node-size multiplier used to push labels along the
+#'   linkage segment away from scaled residue polygons.
 #'
 #' @returns A list with two numeric 2-row matrices, `chil` and `par`. Each
 #'   matrix is an `(x, y)` offset vector to add to the child or parent residue
@@ -65,13 +65,13 @@
   chil_annot_loc <- chil_rotate_matrix %*% chil_location
   par_annot_loc <- par_rotate_matrix %*% par_location
   extra_offset <- .annotation_extra_offset(node_size)
-  chil_annot_loc <- .push_label_position_away_from_segment(
+  chil_annot_loc <- .push_label_position_along_segment(
     label_offset = chil_annot_loc,
     anchor = c(x = chil_glyx, y = chil_glyy),
     other = c(x = par_glyx, y = par_glyy),
     extra_offset = extra_offset
   )
-  par_annot_loc <- .push_label_position_away_from_segment(
+  par_annot_loc <- .push_label_position_along_segment(
     label_offset = par_annot_loc,
     anchor = c(x = par_glyx, y = par_glyy),
     other = c(x = chil_glyx, y = chil_glyy),
@@ -91,17 +91,17 @@
   .default_node_point_size * pmax(node_size - 1, 0)
 }
 
-#' Push a linkage label offset away from its linkage segment
+#' Push a linkage label offset along its linkage segment
 #'
 #' @param label_offset A two-row matrix giving the current label offset from
 #'   the anchor residue.
 #' @param anchor Numeric `x` and `y` coordinates of the anchor residue.
 #' @param other Numeric `x` and `y` coordinates of the linked residue.
-#' @param extra_offset Numeric distance to add perpendicular to the segment.
+#' @param extra_offset Numeric distance to add along the segment.
 #'
 #' @returns A two-row matrix with the adjusted label offset.
 #' @noRd
-.push_label_position_away_from_segment <- function(
+.push_label_position_along_segment <- function(
   label_offset,
   anchor,
   other,
@@ -117,15 +117,7 @@
     return(label_offset)
   }
 
-  direction_unit <- direction / direction_norm
-  parallel <- sum(label_offset * direction_unit) * direction_unit
-  perpendicular <- label_offset - parallel
-  perpendicular_norm <- norm(perpendicular, type = "2")
-  if (perpendicular_norm <= .Machine$double.eps) {
-    return(label_offset)
-  }
-
-  label_offset + extra_offset * perpendicular / perpendicular_norm
+  label_offset + extra_offset * direction / direction_norm
 }
 
 #' Choose the label offset for one side of a linkage

--- a/R/internal-annotations.R
+++ b/R/internal-annotations.R
@@ -11,6 +11,8 @@
 #'   child-side linkage label.
 #' @param par_offset Numeric distance from the parent residue center to the
 #'   parent-side linkage label.
+#' @param node_size Numeric node-size multiplier used to push labels away from
+#'   scaled residue polygons.
 #'
 #' @returns A list with two numeric 2-row matrices, `chil` and `par`. Each
 #'   matrix is an `(x, y)` offset vector to add to the child or parent residue
@@ -22,7 +24,8 @@
   par_glyx,
   par_glyy,
   chil_offset = 0.4,
-  par_offset = 0.4
+  par_offset = 0.4,
+  node_size = 1
 ) {
   chil_direction <- matrix(
     c(par_glyx - chil_glyx, par_glyy - chil_glyy),
@@ -61,8 +64,68 @@
   )
   chil_annot_loc <- chil_rotate_matrix %*% chil_location
   par_annot_loc <- par_rotate_matrix %*% par_location
+  extra_offset <- .annotation_extra_offset(node_size)
+  chil_annot_loc <- .push_label_position_away_from_segment(
+    label_offset = chil_annot_loc,
+    anchor = c(x = chil_glyx, y = chil_glyy),
+    other = c(x = par_glyx, y = par_glyy),
+    extra_offset = extra_offset
+  )
+  par_annot_loc <- .push_label_position_away_from_segment(
+    label_offset = par_annot_loc,
+    anchor = c(x = par_glyx, y = par_glyy),
+    other = c(x = chil_glyx, y = chil_glyy),
+    extra_offset = extra_offset
+  )
   annot_loc <- list("chil" = chil_annot_loc, "par" = par_annot_loc)
   return(annot_loc)
+}
+
+#' Calculate the extra annotation clearance for scaled nodes
+#'
+#' @param node_size Numeric node-size multiplier.
+#'
+#' @returns A non-negative numeric scalar.
+#' @noRd
+.annotation_extra_offset <- function(node_size) {
+  .default_node_point_size * pmax(node_size - 1, 0)
+}
+
+#' Push a linkage label offset away from its linkage segment
+#'
+#' @param label_offset A two-row matrix giving the current label offset from
+#'   the anchor residue.
+#' @param anchor Numeric `x` and `y` coordinates of the anchor residue.
+#' @param other Numeric `x` and `y` coordinates of the linked residue.
+#' @param extra_offset Numeric distance to add perpendicular to the segment.
+#'
+#' @returns A two-row matrix with the adjusted label offset.
+#' @noRd
+.push_label_position_away_from_segment <- function(
+  label_offset,
+  anchor,
+  other,
+  extra_offset
+) {
+  if (extra_offset <= 0) {
+    return(label_offset)
+  }
+
+  direction <- matrix(other - anchor, ncol = 1)
+  direction_norm <- norm(direction, type = "2")
+  if (direction_norm <= .Machine$double.eps) {
+    return(label_offset)
+  }
+
+  direction_unit <- direction / direction_norm
+  parallel <- sum(label_offset * direction_unit) * direction_unit
+  perpendicular <- label_offset - parallel
+  perpendicular_norm <- norm(perpendicular, type = "2")
+  if (perpendicular_norm <= .Machine$double.eps) {
+    return(label_offset)
+  }
+
+  label_offset + extra_offset * perpendicular / perpendicular_norm
 }
 
 #' Choose the label offset for one side of a linkage
@@ -111,20 +174,22 @@
 #' @param structure An igraph glycan graph whose edges include `linkage`.
 #' @param coor A numeric coordinate matrix with columns `x` and `y`, one row
 #'   per graph vertex.
+#' @param node_size Numeric node-size multiplier used to keep labels outside
+#'   scaled residue polygons.
 #'
 #' @returns A data frame with one or two rows per edge and columns `vertice`,
 #'   `annot`, `x`, `y`, `segment_start_x`, `segment_start_y`, `segment_end_x`,
 #'   and `segment_end_y`. `annot` contains normalized labels such as `alpha`,
 #'   `beta`, or linkage position text.
 #' @noRd
-.linkage_annotation_data <- function(structure, coor) {
+.linkage_annotation_data <- function(structure, coor, node_size = 1) {
   if (igraph::ecount(structure) == 0) {
     return(.empty_linkage_annotation_data())
   }
 
   annotation <- purrr::map_dfr(
     seq_len(length(structure) - 1),
-    \(ver) .linkage_annotation_rows(structure, coor, ver)
+    \(ver) .linkage_annotation_rows(structure, coor, ver, node_size = node_size)
   )
   annotation$annot <- .normalize_linkage_labels(annotation$annot)
   annotation
@@ -156,22 +221,30 @@
 #' @param coor A numeric coordinate matrix with columns `x` and `y`, one row
 #'   per graph vertex.
 #' @param ver A single integer child vertex index.
+#' @param node_size Numeric node-size multiplier used to keep labels outside
+#'   scaled residue polygons.
 #'
 #' @returns A two-row data frame with linkage annotation columns. The first row
 #'   is the child-side anomer label and the second row is the parent-side
 #'   linkage-position label.
 #' @noRd
-.linkage_annotation_rows <- function(structure, coor, ver) {
+.linkage_annotation_rows <- function(structure, coor, ver, node_size = 1) {
   par_ver <- .parent_vertex_for_annotation(structure, ver)
   labels <- strsplit(igraph::E(structure)[ver]$linkage, '-')[[1]]
-  offsets <- .linkage_label_offsets(structure, coor, ver, par_ver)
+  offsets <- .linkage_label_offsets(
+    structure,
+    coor,
+    ver,
+    par_ver
+  )
   label_positions <- .linkage_label_positions(
     coor[ver, "x"],
     coor[ver, "y"],
     coor[par_ver, "x"],
     coor[par_ver, "y"],
     chil_offset = offsets[["child"]],
-    par_offset = offsets[["parent"]]
+    par_offset = offsets[["parent"]],
+    node_size = node_size
   )
 
   dplyr::bind_rows(
@@ -243,6 +316,18 @@
       role = "parent"
     )
   )
+}
+
+#' Scale one annotation offset for larger residue nodes
+#'
+#' @param offset Numeric default label offset.
+#' @param node_size Numeric node-size multiplier.
+#'
+#' @returns A numeric scalar offset. The value grows with the extra node radius
+#'   but remains below the midpoint between unit-spaced residue centers.
+#' @noRd
+.scaled_annotation_offset <- function(offset, node_size) {
+  pmin(offset + .annotation_extra_offset(node_size), 0.49)
 }
 
 #' Build one linkage annotation row
@@ -688,12 +773,19 @@
 #' @param coor A numeric coordinate matrix with columns `x` and `y`, one row
 #'   per graph vertex.
 #' @param orient Drawing orientation, either `"H"` or `"V"`.
+#' @param node_size Numeric node-size multiplier used to keep labels outside
+#'   scaled residue polygons.
 #'
 #' @returns A data frame with columns `vertice`, `annot`, `x`, and `y`.
 #'   Unknown linkage prefixes such as `?` are removed from `annot`. Returns an
 #'   empty data frame with the same columns when no substituents are present.
 #' @noRd
-.substituent_annotation_data <- function(structure, coor, orient) {
+.substituent_annotation_data <- function(
+  structure,
+  coor,
+  orient,
+  node_size = 1
+) {
   sub <- igraph::V(structure)$sub
   if (length(sub) == 0) {
     return(data.frame(
@@ -715,10 +807,11 @@
     ))
   }
 
+  offset_distance <- .scaled_annotation_offset(0.4, node_size)
   offset <- if (orient == "H") {
-    c(x = 0, y = 0.4)
+    c(x = 0, y = offset_distance)
   } else {
-    c(x = 0.4, y = 0)
+    c(x = offset_distance, y = 0)
   }
 
   data.frame(

--- a/R/internal-cartoon.R
+++ b/R/internal-cartoon.R
@@ -3,6 +3,24 @@
 
 .default_node_point_size <- 0.215
 .node_size_linkage_threshold <- 1.2
+.node_size_upper_boundary <- 2
+
+#' Validate node-size input
+#'
+#' @param node_size Numeric node-size multiplier.
+#'
+#' @returns `node_size`, invisibly.
+#' @noRd
+.validate_node_size <- function(node_size) {
+  checkmate::assert_number(node_size, lower = 0)
+  if (node_size > .node_size_upper_boundary) {
+    cli::cli_abort(
+      "{.arg node_size} must be no larger than {.val {(.node_size_upper_boundary)}} because larger values make residues overlap."
+    )
+  }
+
+  invisible(node_size)
+}
 
 #' Resolve whether text annotations can be shown for the requested node size
 #'

--- a/R/internal-cartoon.R
+++ b/R/internal-cartoon.R
@@ -1,6 +1,30 @@
 # Internal helpers for turning prepared glycan geometry into ggplot layers,
 # fixed-size cartoon metadata, residue polygons, segments, and text layers.
 
+.default_node_point_size <- 0.215
+.node_size_linkage_threshold <- 1.2
+
+#' Resolve whether text annotations can be shown for the requested node size
+#'
+#' @param show_linkage Logical scalar requested by the user.
+#' @param node_size Numeric node-size multiplier.
+#'
+#' @returns A logical scalar indicating whether the regular text annotation
+#'   layer should be drawn.
+#' @noRd
+.resolve_linkage_visibility <- function(show_linkage, node_size) {
+  checkmate::assert_flag(show_linkage)
+  if (!show_linkage || node_size <= .node_size_linkage_threshold) {
+    return(show_linkage)
+  }
+
+  cli::cli_warn(c(
+    "Linkage annotations are hidden because {.arg node_size} is larger than {.val {(.node_size_linkage_threshold)}}.",
+    "i" = "Set {.arg show_linkage = FALSE} to silence this warning, or use a smaller {.arg node_size}."
+  ))
+  FALSE
+}
+
 #' Convert residue centers to polygon vertices
 #'
 #' @param gly_list A data frame with columns `center_x`, `center_y`,
@@ -135,6 +159,8 @@
 #' @param red_end A string reducing-end annotation.
 #' @param highlight `NULL` or a numeric vector of 1-based vertex indices to
 #'   highlight.
+#' @param node_size Numeric scalar used as a multiplier for the default node
+#'   size.
 #'
 #' @returns A list with `annotation`, the complete text annotation data frame;
 #'   `red_end_text`, only custom reducing-end text rows; and `reducing_info`,
@@ -145,12 +171,18 @@
   coor,
   orient = c("H", "V"),
   red_end = "",
-  highlight = NULL
+  highlight = NULL,
+  node_size = 1
 ) {
   orient <- rlang::arg_match(orient)
   struc_annotation <- dplyr::bind_rows(
-    .linkage_annotation_data(structure, coor),
-    .substituent_annotation_data(structure, coor, orient)
+    .linkage_annotation_data(structure, coor, node_size = node_size),
+    .substituent_annotation_data(
+      structure,
+      coor,
+      orient,
+      node_size = node_size
+    )
   )
   reducing_info <- .reducing_end_annotation_data(
     structure,

--- a/man/draw_cartoon.Rd
+++ b/man/draw_cartoon.Rd
@@ -37,7 +37,8 @@ borders. Defaults to the current value, \code{0.8}.}
 \item{node_size}{Numeric scalar used as a multiplier for the default node
 size. Defaults to \code{1}, which keeps the current size. Linkage annotations
 are moved farther from larger nodes, and are hidden with a warning when
-\code{node_size} is too large to leave enough annotation space.}
+\code{node_size} is too large to leave enough annotation space. Values larger
+than \code{2} are rejected because residues overlap.}
 
 \item{highlight}{An integer vector specifying the node indices to highlight.
 This argument is applicable only when \code{structure} is a \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}}.

--- a/man/draw_cartoon.Rd
+++ b/man/draw_cartoon.Rd
@@ -11,6 +11,7 @@ draw_cartoon(
   red_end = "",
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
+  node_size = 1,
   highlight = NULL
 )
 }
@@ -32,6 +33,11 @@ lines. Defaults to the current value, \code{0.8}.}
 
 \item{node_linewidth}{Numeric scalar controlling the linewidth of node
 borders. Defaults to the current value, \code{0.8}.}
+
+\item{node_size}{Numeric scalar used as a multiplier for the default node
+size. Defaults to \code{1}, which keeps the current size. Linkage annotations
+are moved farther from larger nodes, and are hidden with a warning when
+\code{node_size} is too large to leave enough annotation space.}
 
 \item{highlight}{An integer vector specifying the node indices to highlight.
 This argument is applicable only when \code{structure} is a \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}}.

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -13,7 +13,8 @@ export_cartoons(
   orient = c("H", "V"),
   red_end = "",
   edge_linewidth = 0.8,
-  node_linewidth = 0.8
+  node_linewidth = 0.8,
+  node_size = 1
 )
 }
 \arguments{
@@ -42,6 +43,11 @@ lines. Defaults to the current value, \code{0.8}.}
 
 \item{node_linewidth}{Numeric scalar controlling the linewidth of node
 borders. Defaults to the current value, \code{0.8}.}
+
+\item{node_size}{Numeric scalar used as a multiplier for the default node
+size. Defaults to \code{1}, which keeps the current size. Linkage annotations
+are moved farther from larger nodes, and are hidden with a warning when
+\code{node_size} is too large to leave enough annotation space.}
 }
 \value{
 The function returns the list of cartoons implicitly.

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -47,7 +47,8 @@ borders. Defaults to the current value, \code{0.8}.}
 \item{node_size}{Numeric scalar used as a multiplier for the default node
 size. Defaults to \code{1}, which keeps the current size. Linkage annotations
 are moved farther from larger nodes, and are hidden with a warning when
-\code{node_size} is too large to leave enough annotation space.}
+\code{node_size} is too large to leave enough annotation space. Values larger
+than \code{2} are rejected because residues overlap.}
 }
 \value{
 The function returns the list of cartoons implicitly.

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -123,6 +123,19 @@ test_that("draw_cartoon warns and hides linkage annotations for oversized nodes"
   expect_false(any(text$label %in% c("alpha", "beta", "3")))
 })
 
+test_that("draw_cartoon rejects node_size values that make residues overlap", {
+  structure <- "Gal(b1-3)GalNAc(a1-"
+
+  expect_error(
+    draw_cartoon(structure, node_size = 2.1),
+    "`node_size` must be no larger than 2"
+  )
+  expect_warning(
+    expect_s3_class(draw_cartoon(structure, node_size = 2), "glydraw_cartoon"),
+    "Linkage annotations are hidden"
+  )
+})
+
 test_that("print.glydraw_cartoon rasterizes fixed-size cartoon for display", {
   structure <- paste0(
     "Gal(b1-4)GlcNAc(b1-2)[Gal(b1-4)GlcNAc(b1-4)]Man(a1-3)",
@@ -536,6 +549,17 @@ test_that("export_cartoons forwards custom node sizes", {
     diff(range(first_custom_node$x)) / diff(range(first_default_node$x)),
     1.2,
     tolerance = 1e-6
+  )
+})
+
+test_that("export_cartoons rejects node_size values that make residues overlap", {
+  glycans <- "Gal(b1-3)GalNAc(a1-"
+  temp_dir <- tempfile()
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+
+  expect_error(
+    suppressMessages(export_cartoons(glycans, temp_dir, node_size = 2.1)),
+    "`node_size` must be no larger than 2"
   )
 })
 

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -47,6 +47,72 @@ test_that("draw_cartoon controls edge and node linewidths", {
   expect_equal(unique(custom_layers[[5]]$linewidth), 1.2)
 })
 
+test_that("draw_cartoon scales node polygons with node_size", {
+  structure <- "Gal(b1-3)GalNAc(a1-"
+
+  default_plot <- draw_cartoon(structure)
+  custom_plot <- draw_cartoon(structure, node_size = 1.2)
+  default_nodes <- ggplot2::ggplot_build(default_plot)$data[[3]]
+  custom_nodes <- ggplot2::ggplot_build(custom_plot)$data[[3]]
+  first_default_node <- default_nodes[
+    default_nodes$group == default_nodes$group[1],
+  ]
+  first_custom_node <- custom_nodes[
+    custom_nodes$group == custom_nodes$group[1],
+  ]
+
+  expect_equal(
+    diff(range(first_custom_node$x)) / diff(range(first_default_node$x)),
+    1.2,
+    tolerance = 1e-6
+  )
+  expect_equal(
+    diff(range(first_custom_node$y)) / diff(range(first_default_node$y)),
+    1.2,
+    tolerance = 1e-6
+  )
+})
+
+test_that("draw_cartoon moves linkage annotations away from larger nodes", {
+  structure <- "Gal(b1-3)GalNAc(a1-"
+
+  default_plot <- draw_cartoon(structure)
+  custom_plot <- draw_cartoon(structure, node_size = 1.2)
+  default_text <- ggplot2::ggplot_build(default_plot)$data[[4]]
+  custom_text <- ggplot2::ggplot_build(custom_plot)$data[[4]]
+  default_beta <- default_text[default_text$label == "beta", ]
+  custom_beta <- custom_text[custom_text$label == "beta", ]
+  child_center <- c(x = -1, y = 0)
+
+  default_distance <- sqrt(
+    (default_beta$x - child_center[["x"]])^2 +
+      (default_beta$y - child_center[["y"]])^2
+  )
+  custom_distance <- sqrt(
+    (custom_beta$x - child_center[["x"]])^2 +
+      (custom_beta$y - child_center[["y"]])^2
+  )
+
+  expect_gt(custom_distance, default_distance)
+})
+
+test_that("draw_cartoon warns and hides linkage annotations for oversized nodes", {
+  structure <- "Gal(b1-3)GalNAc(a1-"
+
+  expect_warning(
+    plot <- draw_cartoon(structure, node_size = 1.25, red_end = "Ser/Thr"),
+    "Linkage annotations are hidden"
+  )
+  text_layers <- purrr::keep(
+    ggplot2::ggplot_build(plot)$data,
+    ~ "label" %in% names(.x)
+  )
+  text <- dplyr::bind_rows(text_layers)
+
+  expect_true(any(text$label == '"Ser/Thr"'))
+  expect_false(any(text$label %in% c("alpha", "beta", "3")))
+})
+
 test_that("print.glydraw_cartoon rasterizes fixed-size cartoon for display", {
   structure <- paste0(
     "Gal(b1-4)GlcNAc(b1-2)[Gal(b1-4)GlcNAc(b1-4)]Man(a1-3)",
@@ -422,6 +488,45 @@ test_that("export_cartoons forwards custom linewidths", {
 
   expect_equal(unique(layers[[1]]$linewidth), 1.1)
   expect_equal(unique(layers[[3]]$linewidth), 0.3)
+})
+
+test_that("export_cartoons forwards custom node sizes", {
+  glycans <- "Gal(b1-3)GalNAc(a1-"
+  default_dir <- tempfile()
+  custom_dir <- tempfile()
+  on.exit(unlink(c(default_dir, custom_dir), recursive = TRUE), add = TRUE)
+  fs::dir_create(default_dir)
+  fs::dir_create(custom_dir)
+
+  suppressMessages(
+    default_result <- export_cartoons(
+      glycans,
+      default_dir,
+      dpi = 72
+    )
+  )
+  suppressMessages(
+    custom_result <- export_cartoons(
+      glycans,
+      custom_dir,
+      dpi = 72,
+      node_size = 1.2
+    )
+  )
+  default_nodes <- ggplot2::ggplot_build(default_result[[1]])$data[[3]]
+  custom_nodes <- ggplot2::ggplot_build(custom_result[[1]])$data[[3]]
+  first_default_node <- default_nodes[
+    default_nodes$group == default_nodes$group[1],
+  ]
+  first_custom_node <- custom_nodes[
+    custom_nodes$group == custom_nodes$group[1],
+  ]
+
+  expect_equal(
+    diff(range(first_custom_node$x)) / diff(range(first_default_node$x)),
+    1.2,
+    tolerance = 1e-6
+  )
 })
 
 test_that("export_cartoons uses character vector names as filenames", {

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -73,7 +73,7 @@ test_that("draw_cartoon scales node polygons with node_size", {
   )
 })
 
-test_that("draw_cartoon moves linkage annotations away from larger nodes", {
+test_that("draw_cartoon moves linkage annotations along the line for larger nodes", {
   structure <- "Gal(b1-3)GalNAc(a1-"
 
   default_plot <- draw_cartoon(structure)
@@ -82,18 +82,28 @@ test_that("draw_cartoon moves linkage annotations away from larger nodes", {
   custom_text <- ggplot2::ggplot_build(custom_plot)$data[[4]]
   default_beta <- default_text[default_text$label == "beta", ]
   custom_beta <- custom_text[custom_text$label == "beta", ]
+  default_three <- default_text[default_text$label == "3", ]
+  custom_three <- custom_text[custom_text$label == "3", ]
   child_center <- c(x = -1, y = 0)
+  parent_center <- c(x = 0, y = 0)
 
-  default_distance <- sqrt(
-    (default_beta$x - child_center[["x"]])^2 +
-      (default_beta$y - child_center[["y"]])^2
-  )
-  custom_distance <- sqrt(
-    (custom_beta$x - child_center[["x"]])^2 +
-      (custom_beta$y - child_center[["y"]])^2
-  )
+  default_beta_line_distance <- abs(default_beta$y - child_center[["y"]])
+  custom_beta_line_distance <- abs(custom_beta$y - child_center[["y"]])
+  default_three_line_distance <- abs(default_three$y - parent_center[["y"]])
+  custom_three_line_distance <- abs(custom_three$y - parent_center[["y"]])
 
-  expect_gt(custom_distance, default_distance)
+  expect_equal(
+    custom_beta_line_distance,
+    default_beta_line_distance,
+    tolerance = 1e-6
+  )
+  expect_equal(
+    custom_three_line_distance,
+    default_three_line_distance,
+    tolerance = 1e-6
+  )
+  expect_gt(custom_beta$x, default_beta$x)
+  expect_lt(custom_three$x, default_three$x)
 })
 
 test_that("draw_cartoon warns and hides linkage annotations for oversized nodes", {


### PR DESCRIPTION
## Summary
- Add `node_size` to `draw_cartoon()` and `export_cartoons()` so residue cartoons can be scaled consistently.
- Keep linkage and substituent annotations outside enlarged nodes, with warnings when labels no longer have enough space.
- Reject oversized values above the overlap limit and document the new behavior in `NEWS.md` and the Rd files.
- Add tests covering scaling, annotation repositioning, warning behavior, and input validation.

## Testing
- Not run (not requested)