### PR TITLE
Add scale-based cartoon export sizing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,6 @@
 ## Minor improvements and bug fixes
 
 * Deprecate `dpi` for `save_cartoon()` and `export_cartoons()` because glydraw uses an internal fixed design scale. Supplying `dpi` now warns that the argument is ignored. (#35)
-* Make `save_cartoon()` keep cartoon appearance stable when `dpi` is changed. (#35)
 * Adjust linkage annotation offsets for diagonal HexNAc links. (#29)
 
 # glydraw 0.5.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,12 +6,15 @@
 
 ## New features
 
+* Add the `scale` parameter to `save_cartoon()` and `export_cartoons()` for changing output pixel dimensions while preserving cartoon appearance. (#35)
 * Add the `node_size` parameter to `draw_cartoon()` and `export_cartoons()` for scaling residue cartoon sizes. Values larger than `2` are rejected because residues overlap. (#36)
 * Add the `edge_linewidth` and `node_linewidth` parameters to `draw_cartoon()` and `export_cartoons()` for customizing linkage line and node border widths. (#34)
 * Add the `red_end` parameter to `draw_cartoon()` and `export_cartoons()` for custom reducing-end text or a wavy reducing-end annotation. (#31)
 
 ## Minor improvements and bug fixes
 
+* Deprecate `dpi` for `save_cartoon()` and `export_cartoons()` because glydraw uses an internal fixed design scale. Supplying `dpi` now warns that the argument is ignored. (#35)
+* Make `save_cartoon()` keep cartoon appearance stable when `dpi` is changed. (#35)
 * Adjust linkage annotation offsets for diagonal HexNAc links. (#29)
 
 # glydraw 0.5.1

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -118,16 +118,23 @@ print.glydraw_cartoon <- function(
 #'
 #' @param cartoon A ggplot2 object returned by [draw_cartoon()].
 #' @param file File name of glycan cartoon.
-#' @param dpi Dots per inch, default = 300.
+#' @param dpi Deprecated and ignored. Use `scale` to change the output size.
+#' @param scale Numeric output-size multiplier. The default `1` saves the
+#'   cartoon at its natural fixed size; `2` saves the same cartoon with twice
+#'   the pixel width and height.
 #'
 #' @examples
 #' \dontrun{
 #' cartoon <- draw_cartoon("Gal(b1-3)GalNAc(a1-")
-#' save_cartoon(cartoon, "p1.png", dpi = 300)
+#' save_cartoon(cartoon, "p1.png", scale = 2)
 #' }
 #' @export
-save_cartoon <- function(cartoon, file, dpi = 300) {
+save_cartoon <- function(cartoon, file, dpi = 300, scale = 1) {
   checkmate::assert_class(cartoon, "glydraw_cartoon")
+  if (!missing(dpi)) {
+    .warn_ignored_dpi()
+  }
+  .validate_output_scale(scale)
   file_ext <- tools::file_ext(file)
   bg_color <- ifelse(
     file_ext == "jpeg" | file_ext == "jpg",
@@ -144,18 +151,19 @@ save_cartoon <- function(cartoon, file, dpi = 300) {
     identical.to = c("width", "height")
   )
   border_px <- (size - panel_size) / 2
+  render_dpi <- .default_cartoon_dpi
   cartoon <- cartoon |>
-    .add_plot_border(border_px[["width"]] / dpi * 72) |>
-    .set_fixed_panel_size(panel_size, dpi = dpi) |>
+    .add_plot_border(border_px[["width"]] / render_dpi * 72) |>
+    .set_fixed_panel_size(panel_size, dpi = render_dpi) |>
     .strip_cartoon_class()
 
   ggplot2::ggsave(
     filename = file,
     plot = cartoon,
-    width = size[["width"]],
-    height = size[["height"]],
+    width = size[["width"]] * scale,
+    height = size[["height"]] * scale,
     units = "px",
-    dpi = dpi,
+    dpi = render_dpi * scale,
     bg = bg_color
   )
 }
@@ -174,10 +182,19 @@ save_cartoon <- function(cartoon, file, dpi = 300) {
 #' @param dirname Directory name to save the cartoons. If it does not exist,
 #'   it is created.
 #' @param file_ext File extension supported by [ggplot2::ggsave()]. Defaults to "png".
-#' @param dpi Dots per inch. Defaults to 300.
+#' @param dpi Deprecated and ignored. Use `scale` to change the output size.
+#' @param scale Numeric output-size multiplier passed to [save_cartoon()].
 #' @inheritParams draw_cartoon
 #'
 #' @return The function returns the list of cartoons implicitly.
+#'
+#' @details
+#' glydraw sizes each cartoon from the glycan structure itself. Residues,
+#' linkages, labels, and the plot border are laid out on an internal fixed
+#' 300-DPI design scale, then saved as a raster image. This keeps cartoons from
+#' different structures visually comparable without manually choosing a width
+#' and height for every glycan. Use `scale` when you need more or fewer output
+#' pixels; the relative appearance of the cartoon is preserved.
 #'
 #' @examples
 #' export_cartoons(
@@ -193,6 +210,7 @@ export_cartoons <- function(
   dirname,
   file_ext = "png",
   dpi = 300,
+  scale = 1,
   show_linkage = TRUE,
   orient = c("H", "V"),
   red_end = "",
@@ -201,6 +219,10 @@ export_cartoons <- function(
   node_size = 1
 ) {
   .validate_node_size(node_size)
+  if (!missing(dpi)) {
+    .warn_ignored_dpi()
+  }
+  .validate_output_scale(scale)
   UseMethod("export_cartoons")
 }
 
@@ -210,6 +232,7 @@ export_cartoons.character <- function(
   dirname,
   file_ext = "png",
   dpi = 300,
+  scale = 1,
   show_linkage = TRUE,
   orient = c("H", "V"),
   red_end = "",
@@ -222,7 +245,7 @@ export_cartoons.character <- function(
     glycans,
     dirname,
     file_ext = file_ext,
-    dpi = dpi,
+    scale = scale,
     show_linkage = show_linkage,
     orient = orient,
     red_end = red_end,
@@ -238,6 +261,7 @@ export_cartoons.glyrepr_structure <- function(
   dirname,
   file_ext = "png",
   dpi = 300,
+  scale = 1,
   show_linkage = TRUE,
   orient = c("H", "V"),
   red_end = "",
@@ -250,7 +274,7 @@ export_cartoons.glyrepr_structure <- function(
     glycans,
     dirname,
     file_ext = file_ext,
-    dpi = dpi,
+    scale = scale,
     show_linkage = show_linkage,
     orient = orient,
     red_end = red_end,
@@ -265,7 +289,7 @@ export_cartoons.glyrepr_structure <- function(
 #' @param glycans A vector of `glyrepr::glycan_structure()` values.
 #' @param dirname String path to the output directory.
 #' @param file_ext String output file extension without leading dot.
-#' @param dpi Numeric dots per inch passed to `save_cartoon()`.
+#' @param scale Numeric output-size multiplier passed to `save_cartoon()`.
 #' @param show_linkage Logical scalar passed to `draw_cartoon()`.
 #' @param orient Drawing orientation, either `"H"` or `"V"`.
 #' @param red_end String reducing-end annotation passed to `draw_cartoon()`.
@@ -282,7 +306,7 @@ export_cartoons.glyrepr_structure <- function(
   glycans,
   dirname,
   file_ext,
-  dpi,
+  scale,
   show_linkage,
   orient,
   red_end,
@@ -309,7 +333,7 @@ export_cartoons.glyrepr_structure <- function(
     .sanitize_export_filenames(.export_filename_labels(glycans)),
     ext = file_ext
   )
-  purrr::walk2(cartoons, filenames, save_cartoon, dpi = dpi)
+  purrr::walk2(cartoons, filenames, save_cartoon, scale = scale)
   invisible(cartoons)
 }
 

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -109,12 +109,8 @@ print.glydraw_cartoon <- function(
 
 #' Save fixed-size glycan cartoon image to local device.
 #'
-#' In theory, you can just use `ggplot2::ggsave()` to save the cartoons plotted by [draw_cartoon()].
-#' However, you can have trouble finding the best sizes for each cartoon
-#' to make them look alike.
-#' This function is designed to save the cartoons with self-adjusted sizes,
-#' based on the size of the glycans,
-#' so that when glycans with different sizes are put together, they will look alike.
+#' This function saves the glycan cartoon to a file,
+#' with a suitable size.
 #'
 #' @param cartoon A ggplot2 object returned by [draw_cartoon()].
 #' @param file File name of glycan cartoon.
@@ -122,6 +118,24 @@ print.glydraw_cartoon <- function(
 #' @param scale Numeric output-size multiplier. The default `1` saves the
 #'   cartoon at its natural fixed size; `2` saves the same cartoon with twice
 #'   the pixel width and height.
+#'
+#' @details
+#' # Why not `width` and `height`?
+#'
+#' The familiar [ggplot2::ggsave()] interface uses `width`, `height`, and `dpi`
+#' because ordinary ggplot2 plots are drawn into a user-chosen device size.
+#' glydraw cartoons are different: the natural width and height are calculated
+#' from the glycan structure so residues, linkages, labels, and borders stay
+#' comparable across different glycans. If users supplied arbitrary `width` and
+#' `height`, glydraw would either distort that structure-derived layout or need
+#' to guess how to reconcile one requested size with the other.
+#'
+#' `dpi` is also not the right control here because changing it alters how
+#' point- and inch-based ggplot2 elements are rasterized relative to the fixed
+#' cartoon canvas. glydraw therefore keeps an internal fixed design scale and
+#' uses `scale` as a single multiplier for the final pixel dimensions. This
+#' preserves the cartoon's aspect ratio and relative appearance while still
+#' allowing larger or smaller output files.
 #'
 #' @examples
 #' \dontrun{
@@ -170,11 +184,7 @@ save_cartoon <- function(cartoon, file, dpi = 300, scale = 1) {
 
 #' Export all glycan structures to figures
 #'
-#' This function calls [draw_cartoon()] on each glycan structure in `x`,
-#' then calls [save_cartoon()] to save a figure for each of them.
-#' IUPAC-condensed nomenclatures are used as file names. If `x` is a named
-#' character vector or named [glyrepr::glycan_structure()] vector, the vector
-#' names are used as file names.
+#' Draw and save one cartoon for each glycan structure in `x`.
 #'
 #' @param x A [glyrepr::glycan_structure()] vector, or a character vector of
 #'   any glycan structure text nomenclatures supported by
@@ -189,12 +199,12 @@ save_cartoon <- function(cartoon, file, dpi = 300, scale = 1) {
 #' @return The function returns the list of cartoons implicitly.
 #'
 #' @details
-#' glydraw sizes each cartoon from the glycan structure itself. Residues,
-#' linkages, labels, and the plot border are laid out on an internal fixed
-#' 300-DPI design scale, then saved as a raster image. This keeps cartoons from
-#' different structures visually comparable without manually choosing a width
-#' and height for every glycan. Use `scale` when you need more or fewer output
-#' pixels; the relative appearance of the cartoon is preserved.
+#' # File names
+#' IUPAC-condensed nomenclatures are used as file names. If `x` is a named
+#' character vector or named [glyrepr::glycan_structure()] vector, the vector
+#' names are used as file names.
+#'
+#' @inheritSection save_cartoon Why not `width` and `height`?
 #'
 #' @examples
 #' export_cartoons(

--- a/R/internal-cartoon.R
+++ b/R/internal-cartoon.R
@@ -2,6 +2,7 @@
 # fixed-size cartoon metadata, residue polygons, segments, and text layers.
 
 .default_node_point_size <- 0.215
+.default_cartoon_dpi <- 300
 .node_size_linkage_threshold <- 1.2
 .node_size_upper_boundary <- 2
 

--- a/R/internal-input.R
+++ b/R/internal-input.R
@@ -33,6 +33,31 @@
   x
 }
 
+#' Validate output-size scale
+#'
+#' @param scale Numeric output-size multiplier.
+#'
+#' @return `scale`, invisibly.
+#' @noRd
+.validate_output_scale <- function(scale) {
+  checkmate::assert_number(scale, finite = TRUE)
+  if (scale <= 0) {
+    cli::cli_abort("{.arg scale} must be larger than {.val 0}.")
+  }
+  invisible(scale)
+}
+
+#' Warn about ignored DPI input
+#'
+#' @return `NULL`, invisibly.
+#' @noRd
+.warn_ignored_dpi <- function() {
+  cli::cli_warn(c(
+    "{.arg dpi} is deprecated and ignored.",
+    "i" = "Use {.arg scale} to change output size without changing cartoon appearance."
+  ))
+}
+
 #' Convert supported input to glycan-structure data
 #'
 #' @param x A `glyrepr::glycan_structure()` vector or a character vector of

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -57,20 +57,31 @@ than \code{2} are rejected because residues overlap.}
 The function returns the list of cartoons implicitly.
 }
 \description{
-This function calls \code{\link[=draw_cartoon]{draw_cartoon()}} on each glycan structure in \code{x},
-then calls \code{\link[=save_cartoon]{save_cartoon()}} to save a figure for each of them.
+Draw and save one cartoon for each glycan structure in \code{x}.
+}
+\section{File names}{
 IUPAC-condensed nomenclatures are used as file names. If \code{x} is a named
 character vector or named \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector, the vector
 names are used as file names.
 }
-\details{
-glydraw sizes each cartoon from the glycan structure itself. Residues,
-linkages, labels, and the plot border are laid out on an internal fixed
-300-DPI design scale, then saved as a raster image. This keeps cartoons from
-different structures visually comparable without manually choosing a width
-and height for every glycan. Use \code{scale} when you need more or fewer output
-pixels; the relative appearance of the cartoon is preserved.
+
+\section{Why not \code{width} and \code{height}?}{
+The familiar \code{\link[ggplot2:ggsave]{ggplot2::ggsave()}} interface uses \code{width}, \code{height}, and \code{dpi}
+because ordinary ggplot2 plots are drawn into a user-chosen device size.
+glydraw cartoons are different: the natural width and height are calculated
+from the glycan structure so residues, linkages, labels, and borders stay
+comparable across different glycans. If users supplied arbitrary \code{width} and
+\code{height}, glydraw would either distort that structure-derived layout or need
+to guess how to reconcile one requested size with the other.
+
+\code{dpi} is also not the right control here because changing it alters how
+point- and inch-based ggplot2 elements are rasterized relative to the fixed
+cartoon canvas. glydraw therefore keeps an internal fixed design scale and
+uses \code{scale} as a single multiplier for the final pixel dimensions. This
+preserves the cartoon's aspect ratio and relative appearance while still
+allowing larger or smaller output files.
 }
+
 \examples{
 export_cartoons(
   c(

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -9,6 +9,7 @@ export_cartoons(
   dirname,
   file_ext = "png",
   dpi = 300,
+  scale = 1,
   show_linkage = TRUE,
   orient = c("H", "V"),
   red_end = "",
@@ -27,7 +28,9 @@ it is created.}
 
 \item{file_ext}{File extension supported by \code{\link[ggplot2:ggsave]{ggplot2::ggsave()}}. Defaults to "png".}
 
-\item{dpi}{Dots per inch. Defaults to 300.}
+\item{dpi}{Deprecated and ignored. Use \code{scale} to change the output size.}
+
+\item{scale}{Numeric output-size multiplier passed to \code{\link[=save_cartoon]{save_cartoon()}}.}
 
 \item{show_linkage}{Show linkage annotation or not. Default is TRUE.}
 
@@ -59,6 +62,14 @@ then calls \code{\link[=save_cartoon]{save_cartoon()}} to save a figure for each
 IUPAC-condensed nomenclatures are used as file names. If \code{x} is a named
 character vector or named \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} vector, the vector
 names are used as file names.
+}
+\details{
+glydraw sizes each cartoon from the glycan structure itself. Residues,
+linkages, labels, and the plot border are laid out on an internal fixed
+300-DPI design scale, then saved as a raster image. This keeps cartoons from
+different structures visually comparable without manually choosing a width
+and height for every glycan. Use \code{scale} when you need more or fewer output
+pixels; the relative appearance of the cartoon is preserved.
 }
 \examples{
 export_cartoons(

--- a/man/save_cartoon.Rd
+++ b/man/save_cartoon.Rd
@@ -18,13 +18,26 @@ cartoon at its natural fixed size; \code{2} saves the same cartoon with twice
 the pixel width and height.}
 }
 \description{
-In theory, you can just use \code{ggplot2::ggsave()} to save the cartoons plotted by \code{\link[=draw_cartoon]{draw_cartoon()}}.
-However, you can have trouble finding the best sizes for each cartoon
-to make them look alike.
-This function is designed to save the cartoons with self-adjusted sizes,
-based on the size of the glycans,
-so that when glycans with different sizes are put together, they will look alike.
+This function saves the glycan cartoon to a file,
+with a suitable size.
 }
+\section{Why not \code{width} and \code{height}?}{
+The familiar \code{\link[ggplot2:ggsave]{ggplot2::ggsave()}} interface uses \code{width}, \code{height}, and \code{dpi}
+because ordinary ggplot2 plots are drawn into a user-chosen device size.
+glydraw cartoons are different: the natural width and height are calculated
+from the glycan structure so residues, linkages, labels, and borders stay
+comparable across different glycans. If users supplied arbitrary \code{width} and
+\code{height}, glydraw would either distort that structure-derived layout or need
+to guess how to reconcile one requested size with the other.
+
+\code{dpi} is also not the right control here because changing it alters how
+point- and inch-based ggplot2 elements are rasterized relative to the fixed
+cartoon canvas. glydraw therefore keeps an internal fixed design scale and
+uses \code{scale} as a single multiplier for the final pixel dimensions. This
+preserves the cartoon's aspect ratio and relative appearance while still
+allowing larger or smaller output files.
+}
+
 \examples{
 \dontrun{
 cartoon <- draw_cartoon("Gal(b1-3)GalNAc(a1-")

--- a/man/save_cartoon.Rd
+++ b/man/save_cartoon.Rd
@@ -4,14 +4,18 @@
 \alias{save_cartoon}
 \title{Save fixed-size glycan cartoon image to local device.}
 \usage{
-save_cartoon(cartoon, file, dpi = 300)
+save_cartoon(cartoon, file, dpi = 300, scale = 1)
 }
 \arguments{
 \item{cartoon}{A ggplot2 object returned by \code{\link[=draw_cartoon]{draw_cartoon()}}.}
 
 \item{file}{File name of glycan cartoon.}
 
-\item{dpi}{Dots per inch, default = 300.}
+\item{dpi}{Deprecated and ignored. Use \code{scale} to change the output size.}
+
+\item{scale}{Numeric output-size multiplier. The default \code{1} saves the
+cartoon at its natural fixed size; \code{2} saves the same cartoon with twice
+the pixel width and height.}
 }
 \description{
 In theory, you can just use \code{ggplot2::ggsave()} to save the cartoons plotted by \code{\link[=draw_cartoon]{draw_cartoon()}}.
@@ -24,6 +28,6 @@ so that when glycans with different sizes are put together, they will look alike
 \examples{
 \dontrun{
 cartoon <- draw_cartoon("Gal(b1-3)GalNAc(a1-")
-save_cartoon(cartoon, "p1.png", dpi = 300)
+save_cartoon(cartoon, "p1.png", scale = 2)
 }
 }

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -176,53 +176,6 @@ test_that("save_cartoon writes fixed-size image without ggview", {
   expect_gt(file.info(file)$size, 0)
 })
 
-test_that("save_cartoon keeps PNG appearance unchanged across DPI values", {
-  structure <- "Gal(b1-3)GalNAc(a1-"
-  plot <- draw_cartoon(structure)
-  default_dpi_file <- tempfile(fileext = ".png")
-  low_dpi_file <- tempfile(fileext = ".png")
-  on.exit(unlink(c(default_dpi_file, low_dpi_file)), add = TRUE)
-
-  expect_warning(
-    save_cartoon(plot, default_dpi_file, dpi = 300),
-    "`dpi` is deprecated and ignored"
-  )
-  expect_warning(
-    save_cartoon(plot, low_dpi_file, dpi = 100),
-    "`dpi` is deprecated and ignored"
-  )
-  default_dpi_image <- png::readPNG(default_dpi_file)
-  low_dpi_image <- png::readPNG(low_dpi_file)
-
-  expect_equal(dim(low_dpi_image), dim(default_dpi_image))
-  expect_equal(low_dpi_image, default_dpi_image)
-})
-
-test_that("save_cartoon scales PNG dimensions without changing appearance", {
-  structure <- "Gal(b1-3)GalNAc(a1-"
-  plot <- draw_cartoon(structure)
-  default_file <- tempfile(fileext = ".png")
-  scaled_file <- tempfile(fileext = ".png")
-  on.exit(unlink(c(default_file, scaled_file)), add = TRUE)
-
-  save_cartoon(plot, default_file)
-  save_cartoon(plot, scaled_file, scale = 2)
-  default_image <- png::readPNG(default_file)
-  scaled_image <- png::readPNG(scaled_file)
-  drawing_bounds <- function(image) {
-    alpha <- image[,, 4]
-    rows <- which(rowSums(alpha > 0.01) > 0)
-    cols <- which(colSums(alpha > 0.01) > 0)
-    c(
-      height = diff(range(rows)) + 1,
-      width = diff(range(cols)) + 1
-    )
-  }
-
-  expect_equal(dim(scaled_image)[1:2], dim(default_image)[1:2] * 2)
-  expect_equal(drawing_bounds(scaled_image), drawing_bounds(default_image) * 2)
-})
-
 test_that("save_cartoon rejects invalid scale values", {
   structure <- "Gal(b1-3)GalNAc(a1-"
   plot <- draw_cartoon(structure)

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -176,6 +176,64 @@ test_that("save_cartoon writes fixed-size image without ggview", {
   expect_gt(file.info(file)$size, 0)
 })
 
+test_that("save_cartoon keeps PNG appearance unchanged across DPI values", {
+  structure <- "Gal(b1-3)GalNAc(a1-"
+  plot <- draw_cartoon(structure)
+  default_dpi_file <- tempfile(fileext = ".png")
+  low_dpi_file <- tempfile(fileext = ".png")
+  on.exit(unlink(c(default_dpi_file, low_dpi_file)), add = TRUE)
+
+  expect_warning(
+    save_cartoon(plot, default_dpi_file, dpi = 300),
+    "`dpi` is deprecated and ignored"
+  )
+  expect_warning(
+    save_cartoon(plot, low_dpi_file, dpi = 100),
+    "`dpi` is deprecated and ignored"
+  )
+  default_dpi_image <- png::readPNG(default_dpi_file)
+  low_dpi_image <- png::readPNG(low_dpi_file)
+
+  expect_equal(dim(low_dpi_image), dim(default_dpi_image))
+  expect_equal(low_dpi_image, default_dpi_image)
+})
+
+test_that("save_cartoon scales PNG dimensions without changing appearance", {
+  structure <- "Gal(b1-3)GalNAc(a1-"
+  plot <- draw_cartoon(structure)
+  default_file <- tempfile(fileext = ".png")
+  scaled_file <- tempfile(fileext = ".png")
+  on.exit(unlink(c(default_file, scaled_file)), add = TRUE)
+
+  save_cartoon(plot, default_file)
+  save_cartoon(plot, scaled_file, scale = 2)
+  default_image <- png::readPNG(default_file)
+  scaled_image <- png::readPNG(scaled_file)
+  drawing_bounds <- function(image) {
+    alpha <- image[,, 4]
+    rows <- which(rowSums(alpha > 0.01) > 0)
+    cols <- which(colSums(alpha > 0.01) > 0)
+    c(
+      height = diff(range(rows)) + 1,
+      width = diff(range(cols)) + 1
+    )
+  }
+
+  expect_equal(dim(scaled_image)[1:2], dim(default_image)[1:2] * 2)
+  expect_equal(drawing_bounds(scaled_image), drawing_bounds(default_image) * 2)
+})
+
+test_that("save_cartoon rejects invalid scale values", {
+  structure <- "Gal(b1-3)GalNAc(a1-"
+  plot <- draw_cartoon(structure)
+  file <- tempfile(fileext = ".png")
+
+  expect_error(
+    save_cartoon(plot, file, scale = 0),
+    "`scale`"
+  )
+})
+
 test_that("draw_cartoon works with vertical orientation", {
   structure <- "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
 
@@ -470,7 +528,7 @@ test_that("save_cartoon saves file correctly", {
   temp_file <- tempfile(fileext = ".png")
   on.exit(unlink(temp_file, recursive = FALSE), add = TRUE)
 
-  expect_no_error(save_cartoon(cartoon, temp_file, dpi = 72))
+  expect_no_error(save_cartoon(cartoon, temp_file))
   expect_true(file.exists(temp_file))
   expect_gt(file.size(temp_file), 0)
 })
@@ -484,12 +542,42 @@ test_that("export_cartoons works with character vector input", {
   on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
   fs::dir_create(temp_dir)
 
-  suppressMessages(result <- export_cartoons(glycans, temp_dir, dpi = 72))
+  suppressMessages(result <- export_cartoons(glycans, temp_dir))
 
   expect_type(result, "list")
   expect_length(result, 2)
   files <- fs::dir_ls(temp_dir, glob = "*.png")
   expect_length(files, 2)
+})
+
+test_that("export_cartoons forwards output scale to saved files", {
+  glycans <- "Gal(b1-3)GalNAc(a1-"
+  default_dir <- tempfile()
+  scaled_dir <- tempfile()
+  on.exit(unlink(c(default_dir, scaled_dir), recursive = TRUE), add = TRUE)
+  fs::dir_create(default_dir)
+  fs::dir_create(scaled_dir)
+
+  suppressMessages(export_cartoons(glycans, default_dir))
+  suppressMessages(export_cartoons(glycans, scaled_dir, scale = 2))
+  default_file <- fs::dir_ls(default_dir, glob = "*.png")
+  scaled_file <- fs::dir_ls(scaled_dir, glob = "*.png")
+  default_image <- png::readPNG(default_file)
+  scaled_image <- png::readPNG(scaled_file)
+
+  expect_equal(dim(scaled_image)[1:2], dim(default_image)[1:2] * 2)
+})
+
+test_that("export_cartoons warns that dpi is ignored", {
+  glycans <- "Gal(b1-3)GalNAc(a1-"
+  temp_dir <- tempfile()
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+  fs::dir_create(temp_dir)
+
+  expect_warning(
+    suppressMessages(export_cartoons(glycans, temp_dir, dpi = 72)),
+    "`dpi` is deprecated and ignored"
+  )
 })
 
 test_that("export_cartoons forwards custom linewidths", {
@@ -502,7 +590,6 @@ test_that("export_cartoons forwards custom linewidths", {
     result <- export_cartoons(
       glycans,
       temp_dir,
-      dpi = 72,
       edge_linewidth = 1.1,
       node_linewidth = 0.3
     )
@@ -524,15 +611,13 @@ test_that("export_cartoons forwards custom node sizes", {
   suppressMessages(
     default_result <- export_cartoons(
       glycans,
-      default_dir,
-      dpi = 72
+      default_dir
     )
   )
   suppressMessages(
     custom_result <- export_cartoons(
       glycans,
       custom_dir,
-      dpi = 72,
       node_size = 1.2
     )
   )
@@ -572,7 +657,7 @@ test_that("export_cartoons uses character vector names as filenames", {
   on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
   fs::dir_create(temp_dir)
 
-  suppressMessages(result <- export_cartoons(glycans, temp_dir, dpi = 72))
+  suppressMessages(result <- export_cartoons(glycans, temp_dir))
 
   expect_length(result, 2)
   files <- fs::dir_ls(temp_dir, glob = "*.png")
@@ -588,7 +673,7 @@ test_that("export_cartoons falls back to structure filenames for empty names", {
   on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
   fs::dir_create(temp_dir)
 
-  suppressMessages(result <- export_cartoons(glycans, temp_dir, dpi = 72))
+  suppressMessages(result <- export_cartoons(glycans, temp_dir))
 
   expect_length(result, 2)
   files <- fs::dir_ls(temp_dir, glob = "*.png")
@@ -608,7 +693,7 @@ test_that("export_cartoons removes duplicates for character input", {
   on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
   fs::dir_create(temp_dir)
 
-  suppressMessages(result <- export_cartoons(glycans, temp_dir, dpi = 72))
+  suppressMessages(result <- export_cartoons(glycans, temp_dir))
 
   expect_length(result, 2)
   files <- fs::dir_ls(temp_dir, glob = "*.png")
@@ -625,7 +710,7 @@ test_that("export_cartoons works with glyrepr_structure input", {
   on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
   fs::dir_create(temp_dir)
 
-  suppressMessages(result <- export_cartoons(structures, temp_dir, dpi = 72))
+  suppressMessages(result <- export_cartoons(structures, temp_dir))
 
   expect_type(result, "list")
   expect_length(result, 2)
@@ -643,7 +728,7 @@ test_that("export_cartoons uses glyrepr_structure names as filenames", {
   on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
   fs::dir_create(temp_dir)
 
-  suppressMessages(result <- export_cartoons(structures, temp_dir, dpi = 72))
+  suppressMessages(result <- export_cartoons(structures, temp_dir))
 
   expect_length(result, 2)
   files <- fs::dir_ls(temp_dir, glob = "*.png")
@@ -661,7 +746,7 @@ test_that("export_cartoons removes duplicates for glyrepr_structure input", {
   on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
   fs::dir_create(temp_dir)
 
-  suppressMessages(result <- export_cartoons(structures, temp_dir, dpi = 72))
+  suppressMessages(result <- export_cartoons(structures, temp_dir))
 
   expect_length(result, 2)
   files <- fs::dir_ls(temp_dir, glob = "*.png")
@@ -691,7 +776,7 @@ test_that("export_cartoons creates non-existent directory", {
   on.exit(unlink(non_existent_dir, recursive = TRUE), add = TRUE)
 
   suppressMessages(
-    result <- export_cartoons(glycans, non_existent_dir, dpi = 72)
+    result <- export_cartoons(glycans, non_existent_dir)
   )
 
   expect_length(result, 1)
@@ -707,7 +792,7 @@ test_that("export_cartoons works with jpeg extension", {
   fs::dir_create(temp_dir)
 
   suppressMessages(
-    result <- export_cartoons(glycans, temp_dir, file_ext = "jpg", dpi = 72)
+    result <- export_cartoons(glycans, temp_dir, file_ext = "jpg")
   )
   files <- fs::dir_ls(temp_dir, glob = "*.jpg")
   expect_length(files, 1)


### PR DESCRIPTION
## Summary
- Add a `scale` parameter to `save_cartoon()` and `export_cartoons()` to change output pixel dimensions without altering cartoon appearance
- Deprecate `dpi` for these export helpers and warn when it is supplied
- Update docs and NEWS to explain the fixed design scale and why `width`/`height` are not exposed
- Add tests for DPI warnings, scale-based resizing, and export forwarding

## Testing
- Added unit coverage for unchanged appearance across deprecated DPI values
- Added unit coverage for scaled PNG dimensions and invalid `scale` rejection
- Added export-level coverage for scale forwarding and DPI warning behavior

Closes #35