### PR TITLE
Align glydraw helpers with ignored variadic arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Breaking changes
 
 * `export_cartoons()` no longer supports `glyexp::experiment()` input, and `glyexp` is no longer a package dependency. (#33)
+* Specifying optianl arguments in a positional manner is no longer supported. Please use `arg = value` instead. (#40)
 
 ## New features
 

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -2,6 +2,7 @@
 #'
 #' @param structure A [glyrepr::glycan_structure()] scalar,
 #'   or a string of any glycan structure text nomenclatures supported by [glyparse::auto_parse()].
+#' @param ... Ignored.
 #' @param show_linkage Show linkage annotation or not. Default is TRUE.
 #' @param orient The orientation of glycan structure. "H" for horizontal, "V" for vertical.
 #'   Default is "H"
@@ -32,6 +33,7 @@
 #' @export
 draw_cartoon <- function(
   structure,
+  ...,
   show_linkage = TRUE,
   orient = c("H", "V"),
   red_end = "",
@@ -85,17 +87,17 @@ draw_cartoon <- function(
 #' Print glycan cartoon
 #'
 #' @param x A ggplot2 object returned by [draw_cartoon()].
+#' @param ... Ignored.
 #' @param newpage Draw the plot on a new page.
 #' @param vp A grid viewport object or viewport name.
-#' @param ... Additional arguments passed to ggplot2's print method.
 #'
 #' @return The original glycan cartoon, invisibly.
 #' @export
 print.glydraw_cartoon <- function(
   x,
+  ...,
   newpage = is.null(vp),
-  vp = NULL,
-  ...
+  vp = NULL
 ) {
   raster <- .render_cartoon_raster(x)
   .draw_cartoon_raster(
@@ -114,6 +116,7 @@ print.glydraw_cartoon <- function(
 #'
 #' @param cartoon A ggplot2 object returned by [draw_cartoon()].
 #' @param file File name of glycan cartoon.
+#' @param ... Ignored.
 #' @param dpi Deprecated and ignored. Use `scale` to change the output size.
 #' @param scale Numeric output-size multiplier. The default `1` saves the
 #'   cartoon at its natural fixed size; `2` saves the same cartoon with twice
@@ -143,7 +146,7 @@ print.glydraw_cartoon <- function(
 #' save_cartoon(cartoon, "p1.png", scale = 2)
 #' }
 #' @export
-save_cartoon <- function(cartoon, file, dpi = 300, scale = 1) {
+save_cartoon <- function(cartoon, file, ..., dpi = 300, scale = 1) {
   checkmate::assert_class(cartoon, "glydraw_cartoon")
   if (!missing(dpi)) {
     .warn_ignored_dpi()
@@ -191,6 +194,7 @@ save_cartoon <- function(cartoon, file, dpi = 300, scale = 1) {
 #'   [glyparse::auto_parse()].
 #' @param dirname Directory name to save the cartoons. If it does not exist,
 #'   it is created.
+#' @param ... Ignored.
 #' @param file_ext File extension supported by [ggplot2::ggsave()]. Defaults to "png".
 #' @param dpi Deprecated and ignored. Use `scale` to change the output size.
 #' @param scale Numeric output-size multiplier passed to [save_cartoon()].
@@ -218,6 +222,7 @@ save_cartoon <- function(cartoon, file, dpi = 300, scale = 1) {
 export_cartoons <- function(
   x,
   dirname,
+  ...,
   file_ext = "png",
   dpi = 300,
   scale = 1,
@@ -240,6 +245,7 @@ export_cartoons <- function(
 export_cartoons.character <- function(
   x,
   dirname,
+  ...,
   file_ext = "png",
   dpi = 300,
   scale = 1,
@@ -269,6 +275,7 @@ export_cartoons.character <- function(
 export_cartoons.glyrepr_structure <- function(
   x,
   dirname,
+  ...,
   file_ext = "png",
   dpi = 300,
   scale = 1,

--- a/man/draw_cartoon.Rd
+++ b/man/draw_cartoon.Rd
@@ -6,6 +6,7 @@
 \usage{
 draw_cartoon(
   structure,
+  ...,
   show_linkage = TRUE,
   orient = c("H", "V"),
   red_end = "",
@@ -18,6 +19,8 @@ draw_cartoon(
 \arguments{
 \item{structure}{A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} scalar,
 or a string of any glycan structure text nomenclatures supported by \code{\link[glyparse:auto_parse]{glyparse::auto_parse()}}.}
+
+\item{...}{Ignored.}
 
 \item{show_linkage}{Show linkage annotation or not. Default is TRUE.}
 

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -7,6 +7,7 @@
 export_cartoons(
   x,
   dirname,
+  ...,
   file_ext = "png",
   dpi = 300,
   scale = 1,
@@ -25,6 +26,8 @@ any glycan structure text nomenclatures supported by
 
 \item{dirname}{Directory name to save the cartoons. If it does not exist,
 it is created.}
+
+\item{...}{Ignored.}
 
 \item{file_ext}{File extension supported by \code{\link[ggplot2:ggsave]{ggplot2::ggsave()}}. Defaults to "png".}
 

--- a/man/print.glydraw_cartoon.Rd
+++ b/man/print.glydraw_cartoon.Rd
@@ -4,16 +4,16 @@
 \alias{print.glydraw_cartoon}
 \title{Print glycan cartoon}
 \usage{
-\method{print}{glydraw_cartoon}(x, newpage = is.null(vp), vp = NULL, ...)
+\method{print}{glydraw_cartoon}(x, ..., newpage = is.null(vp), vp = NULL)
 }
 \arguments{
 \item{x}{A ggplot2 object returned by \code{\link[=draw_cartoon]{draw_cartoon()}}.}
 
+\item{...}{Ignored.}
+
 \item{newpage}{Draw the plot on a new page.}
 
 \item{vp}{A grid viewport object or viewport name.}
-
-\item{...}{Additional arguments passed to ggplot2's print method.}
 }
 \value{
 The original glycan cartoon, invisibly.

--- a/man/save_cartoon.Rd
+++ b/man/save_cartoon.Rd
@@ -4,12 +4,14 @@
 \alias{save_cartoon}
 \title{Save fixed-size glycan cartoon image to local device.}
 \usage{
-save_cartoon(cartoon, file, dpi = 300, scale = 1)
+save_cartoon(cartoon, file, ..., dpi = 300, scale = 1)
 }
 \arguments{
 \item{cartoon}{A ggplot2 object returned by \code{\link[=draw_cartoon]{draw_cartoon()}}.}
 
 \item{file}{File name of glycan cartoon.}
+
+\item{...}{Ignored.}
 
 \item{dpi}{Deprecated and ignored. Use \code{scale} to change the output size.}
 


### PR DESCRIPTION
## Summary
- Add ignored `...` arguments to cartoon drawing, printing, saving, and export helpers for API consistency
- Update the corresponding Rd files so the documented signatures match the implementation
- Clarify that the extra arguments are ignored rather than forwarded

## Testing
- Not run (not requested)