### PR TITLE
Keep substituent annotations visible when linkage labels are hidden

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
 ## Minor improvements and bug fixes
 
 * Deprecate `dpi` for `save_cartoon()` and `export_cartoons()` because glydraw uses an internal fixed design scale. Supplying `dpi` now warns that the argument is ignored. (#35)
-* Keep substituent annotations visible when `show_linkage = FALSE`. (#37)
+* Keep substituent annotations visible when `show_linkage = FALSE`. (#41)
 * Adjust linkage annotation offsets for diagonal HexNAc links. (#29)
 
 # glydraw 0.5.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 ## Minor improvements and bug fixes
 
 * Deprecate `dpi` for `save_cartoon()` and `export_cartoons()` because glydraw uses an internal fixed design scale. Supplying `dpi` now warns that the argument is ignored. (#35)
+* Keep substituent annotations visible when `show_linkage = FALSE`. (#37)
 * Adjust linkage annotation offsets for diagonal HexNAc links. (#29)
 
 # glydraw 0.5.1

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -3,7 +3,8 @@
 #' @param structure A [glyrepr::glycan_structure()] scalar,
 #'   or a string of any glycan structure text nomenclatures supported by [glyparse::auto_parse()].
 #' @param ... Ignored.
-#' @param show_linkage Show linkage annotation or not. Default is TRUE.
+#' @param show_linkage Show glycosidic linkage annotations or not. Default is
+#'   TRUE. Substituent annotations are always shown.
 #' @param orient The orientation of glycan structure. "H" for horizontal, "V" for vertical.
 #'   Default is "H"
 #' @param red_end Reducing-end annotation. The default `""` keeps the current

--- a/R/internal-cartoon.R
+++ b/R/internal-cartoon.R
@@ -182,8 +182,9 @@
 #'   size.
 #'
 #' @returns A list with `annotation`, the complete text annotation data frame;
-#'   `red_end_text`, only custom reducing-end text rows; and `reducing_info`,
-#'   the list returned by `.reducing_end_annotation_data()`.
+#'   `show_without_linkage`, substituent and custom reducing-end text rows that
+#'   remain visible when linkage labels are hidden; and `reducing_info`, the
+#'   list returned by `.reducing_end_annotation_data()`.
 #' @noRd
 .cartoon_text_annotation_data <- function(
   structure,
@@ -194,14 +195,22 @@
   node_size = 1
 ) {
   orient <- rlang::arg_match(orient)
+  linkage_annotation <- .linkage_annotation_data(
+    structure,
+    coor,
+    node_size = node_size
+  ) |>
+    dplyr::mutate(show_without_linkage = FALSE)
+  substituent_annotation <- .substituent_annotation_data(
+    structure,
+    coor,
+    orient,
+    node_size = node_size
+  ) |>
+    dplyr::mutate(show_without_linkage = TRUE)
   struc_annotation <- dplyr::bind_rows(
-    .linkage_annotation_data(structure, coor, node_size = node_size),
-    .substituent_annotation_data(
-      structure,
-      coor,
-      orient,
-      node_size = node_size
-    )
+    linkage_annotation,
+    substituent_annotation
   )
   reducing_info <- .reducing_end_annotation_data(
     structure,
@@ -209,9 +218,11 @@
     orient,
     red_end
   )
+  reducing_annotation <- reducing_info$annotation |>
+    dplyr::mutate(show_without_linkage = .data$is_red_end_text)
   struc_annotation <- dplyr::bind_rows(
     struc_annotation,
-    reducing_info$annotation
+    reducing_annotation
   )
   struc_annotation <- .separate_overlapping_annotations(struc_annotation)
   struc_annotation <- .apply_highlight_to_annotations(
@@ -222,7 +233,10 @@
 
   list(
     annotation = struc_annotation,
-    red_end_text = dplyr::filter(struc_annotation, .data$is_red_end_text),
+    show_without_linkage = dplyr::filter(
+      struc_annotation,
+      .data$show_without_linkage
+    ),
     reducing_info = reducing_info
   )
 }
@@ -404,9 +418,8 @@
 #'
 #' @param plot A ggplot object.
 #' @param annotation_data A list returned by `.cartoon_text_annotation_data()`.
-#' @param show_linkage A logical scalar. `TRUE` draws all linkage and
-#'   reducing-end text; `FALSE` draws only custom reducing-end text when
-#'   present.
+#' @param show_linkage A logical scalar. `TRUE` draws all text; `FALSE` draws
+#'   only substituent and custom reducing-end text when present.
 #'
 #' @returns A ggplot object with zero or one added text layer.
 #' @noRd
@@ -418,8 +431,8 @@
   if (show_linkage) {
     return(.add_plotmath_text_layer(plot, annotation_data$annotation))
   }
-  if (nrow(annotation_data$red_end_text) > 0) {
-    return(.add_plotmath_text_layer(plot, annotation_data$red_end_text))
+  if (nrow(annotation_data$show_without_linkage) > 0) {
+    return(.add_plotmath_text_layer(plot, annotation_data$show_without_linkage))
   }
   plot
 }

--- a/man/draw_cartoon.Rd
+++ b/man/draw_cartoon.Rd
@@ -22,7 +22,8 @@ or a string of any glycan structure text nomenclatures supported by \code{\link[
 
 \item{...}{Ignored.}
 
-\item{show_linkage}{Show linkage annotation or not. Default is TRUE.}
+\item{show_linkage}{Show glycosidic linkage annotations or not. Default is
+TRUE. Substituent annotations are always shown.}
 
 \item{orient}{The orientation of glycan structure. "H" for horizontal, "V" for vertical.
 Default is "H"}

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -35,7 +35,8 @@ it is created.}
 
 \item{scale}{Numeric output-size multiplier passed to \code{\link[=save_cartoon]{save_cartoon()}}.}
 
-\item{show_linkage}{Show linkage annotation or not. Default is TRUE.}
+\item{show_linkage}{Show glycosidic linkage annotations or not. Default is
+TRUE. Substituent annotations are always shown.}
 
 \item{orient}{The orientation of glycan structure. "H" for horizontal, "V" for vertical.
 Default is "H"}

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -287,6 +287,20 @@ test_that("draw_cartoon works with linkage hidden", {
   expect_s3_class(plot_no_linkage, "glydraw_cartoon")
 })
 
+test_that("draw_cartoon keeps substituent annotations with linkage hidden", {
+  structure <- "Gal6S(a1-"
+
+  plot <- draw_cartoon(structure, show_linkage = FALSE)
+  text_layers <- purrr::keep(
+    ggplot2::ggplot_build(plot)$data,
+    ~ "label" %in% names(.x)
+  )
+  labels <- unlist(purrr::map(text_layers, "label"), use.names = FALSE)
+
+  expect_true(any(grepl("6S", labels, fixed = TRUE)))
+  expect_false(any(labels == "alpha"))
+})
+
 test_that("draw_cartoon places substituent annotations by orientation", {
   structure <- "GalNAc6S(b1-3)GalNAc(a1-"
 


### PR DESCRIPTION
## Summary
- Keep substituent annotations visible when `show_linkage = FALSE`.
- Preserve custom reducing-end text in the hidden-linkage view.
- Update the `draw_cartoon()` and `export_cartoons()` documentation to match the new behavior.

## Testing
- Added a regression test covering a substituted structure rendered with `show_linkage = FALSE`.
- Verified the hidden-linkage view still includes substituent labels and omits linkage text.

Closes #37