### PR TITLE
feat: add Fuc orientation control

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 
 ## New features
 
+* Add the `fuc_orient` parameter to `draw_cartoon()` and `export_cartoons()` for choosing whether Fuc triangles always point upward or flex toward their linkage direction. (#38)
 * Add the `scale` parameter to `save_cartoon()` and `export_cartoons()` for changing output pixel dimensions while preserving cartoon appearance. (#35)
 * Add the `node_size` parameter to `draw_cartoon()` and `export_cartoons()` for scaling residue cartoon sizes. Values larger than `2` are rejected because residues overlap. (#36)
 * Add the `edge_linewidth` and `node_linewidth` parameters to `draw_cartoon()` and `export_cartoons()` for customizing linkage line and node border widths. (#34)

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 ## New features
 
-* Add the `fuc_orient` parameter to `draw_cartoon()` and `export_cartoons()` for choosing whether Fuc triangles always point upward or flex toward their linkage direction. (#38)
+* Add the `fuc_orient` parameter to `draw_cartoon()` and `export_cartoons()` for choosing whether Fuc triangles always point upward or flex toward their linkage direction. (#42)
 * Add the `scale` parameter to `save_cartoon()` and `export_cartoons()` for changing output pixel dimensions while preserving cartoon appearance. (#35)
 * Add the `node_size` parameter to `draw_cartoon()` and `export_cartoons()` for scaling residue cartoon sizes. Values larger than `2` are rejected because residues overlap. (#36)
 * Add the `edge_linewidth` and `node_linewidth` parameters to `draw_cartoon()` and `export_cartoons()` for customizing linkage line and node border widths. (#34)

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -7,6 +7,10 @@
 #'   TRUE. Substituent annotations are always shown.
 #' @param orient The orientation of glycan structure. "H" for horizontal, "V" for vertical.
 #'   Default is "H"
+#' @param fuc_orient Fuc triangle orientation. `"flex"` points non-reducing Fuc
+#'   residues toward their rendered linkage direction, while `"up"` draws all
+#'   Fuc triangles pointing upward. Reducing-end Fuc residues always point
+#'   upward. Defaults to `"flex"`.
 #' @param red_end Reducing-end annotation. The default `""` keeps the current
 #'   reducing-end line. Use `"~"` to add a wavy reducing end, or any other
 #'   string to draw that string at the reducing end.
@@ -37,6 +41,7 @@ draw_cartoon <- function(
   ...,
   show_linkage = TRUE,
   orient = c("H", "V"),
+  fuc_orient = c("flex", "up"),
   red_end = "",
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
@@ -46,6 +51,7 @@ draw_cartoon <- function(
   checkmate::assert_number(edge_linewidth, lower = 0)
   checkmate::assert_number(node_linewidth, lower = 0)
   .validate_node_size(node_size)
+  fuc_orient <- rlang::arg_match(fuc_orient)
   inputs <- .prepare_cartoon_inputs(structure, highlight, orient, red_end)
   structure <- inputs$structure
   coor <- inputs$coor
@@ -53,7 +59,7 @@ draw_cartoon <- function(
   orient <- inputs$orient
   show_linkage <- .resolve_linkage_visibility(show_linkage, node_size)
 
-  gly_list <- .cartoon_residue_data(structure, coor, highlight)
+  gly_list <- .cartoon_residue_data(structure, coor, highlight, fuc_orient)
   polygon_coor <- .residue_polygon_data(
     gly_list,
     .default_node_point_size * node_size
@@ -229,12 +235,14 @@ export_cartoons <- function(
   scale = 1,
   show_linkage = TRUE,
   orient = c("H", "V"),
+  fuc_orient = c("flex", "up"),
   red_end = "",
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
   node_size = 1
 ) {
   .validate_node_size(node_size)
+  fuc_orient <- rlang::arg_match(fuc_orient)
   if (!missing(dpi)) {
     .warn_ignored_dpi()
   }
@@ -252,6 +260,7 @@ export_cartoons.character <- function(
   scale = 1,
   show_linkage = TRUE,
   orient = c("H", "V"),
+  fuc_orient = c("flex", "up"),
   red_end = "",
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
@@ -265,6 +274,7 @@ export_cartoons.character <- function(
     scale = scale,
     show_linkage = show_linkage,
     orient = orient,
+    fuc_orient = fuc_orient,
     red_end = red_end,
     edge_linewidth = edge_linewidth,
     node_linewidth = node_linewidth,
@@ -282,6 +292,7 @@ export_cartoons.glyrepr_structure <- function(
   scale = 1,
   show_linkage = TRUE,
   orient = c("H", "V"),
+  fuc_orient = c("flex", "up"),
   red_end = "",
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
@@ -295,6 +306,7 @@ export_cartoons.glyrepr_structure <- function(
     scale = scale,
     show_linkage = show_linkage,
     orient = orient,
+    fuc_orient = fuc_orient,
     red_end = red_end,
     edge_linewidth = edge_linewidth,
     node_linewidth = node_linewidth,
@@ -310,6 +322,7 @@ export_cartoons.glyrepr_structure <- function(
 #' @param scale Numeric output-size multiplier passed to `save_cartoon()`.
 #' @param show_linkage Logical scalar passed to `draw_cartoon()`.
 #' @param orient Drawing orientation, either `"H"` or `"V"`.
+#' @param fuc_orient Fuc triangle orientation passed to `draw_cartoon()`.
 #' @param red_end String reducing-end annotation passed to `draw_cartoon()`.
 #' @param edge_linewidth Numeric linkage line width passed to
 #'   `draw_cartoon()`.
@@ -327,12 +340,14 @@ export_cartoons.glyrepr_structure <- function(
   scale,
   show_linkage,
   orient,
+  fuc_orient,
   red_end,
   edge_linewidth,
   node_linewidth,
   node_size
 ) {
   .validate_node_size(node_size)
+  fuc_orient <- rlang::arg_match(fuc_orient, c("flex", "up"))
   cli::cli_alert_info("Exporting {.val {length(glycans)}} glycan cartoons.")
   fs::dir_create(dirname)
   glycan_list <- purrr::map(seq_along(glycans), ~ glycans[[.x]])
@@ -341,6 +356,7 @@ export_cartoons.glyrepr_structure <- function(
     draw_cartoon,
     show_linkage = show_linkage,
     orient = orient,
+    fuc_orient = fuc_orient,
     red_end = red_end,
     edge_linewidth = edge_linewidth,
     node_linewidth = node_linewidth,

--- a/R/internal-cartoon.R
+++ b/R/internal-cartoon.R
@@ -151,12 +151,22 @@
 #' @param coor A numeric coordinate matrix with columns `x` and `y`.
 #' @param highlight `NULL` or a numeric vector of 1-based vertex indices to
 #'   highlight.
+#' @param fuc_orient Fuc triangle orientation, either `"flex"` or `"up"`.
 #'
 #' @returns A data frame with columns `center_x`, `center_y`, `glycoform`, and
 #'   `transparency`, one row per residue vertex.
 #' @noRd
-.cartoon_residue_data <- function(structure, coor, highlight = NULL) {
-  gly_list <- data.frame(coor, glycoform = .residue_glycoforms(structure))
+.cartoon_residue_data <- function(
+  structure,
+  coor,
+  highlight = NULL,
+  fuc_orient = c("flex", "up")
+) {
+  fuc_orient <- rlang::arg_match(fuc_orient)
+  gly_list <- data.frame(
+    coor,
+    glycoform = .residue_glycoforms(structure, coor, fuc_orient)
+  )
   if (!is.null(highlight)) {
     gly_list$transparency <- replace(
       rep(0.3, length(structure)),

--- a/R/internal-coordinates.R
+++ b/R/internal-coordinates.R
@@ -684,20 +684,61 @@
 #' Get drawable residue shape names for graph vertices
 #'
 #' @param structure An igraph glycan graph whose vertices include `mono`.
+#' @param coor A numeric coordinate matrix with rendered columns `x` and `y`,
+#'   one row per graph vertex.
+#' @param fuc_orient Fuc triangle orientation, either `"flex"` or `"up"`.
 #'
 #' @returns A character vector with one value per vertex. Most values are copied
-#'   from `mono`; non-reducing Fuc residues on upward branches are returned as
-#'   `"FucUp"` so the triangle points in the branch direction.
+#'   from `mono`; in flexible Fuc orientation, non-reducing Fuc residues are
+#'   mapped to directional shape names so the triangle apex points toward the
+#'   rendered linkage direction.
 #' @noRd
-.residue_glycoforms <- function(structure) {
+.residue_glycoforms <- function(
+  structure,
+  coor = NULL,
+  fuc_orient = c("flex", "up")
+) {
+  fuc_orient <- rlang::arg_match(fuc_orient)
   glycoform <- igraph::V(structure)$mono
+  if (fuc_orient == "up") {
+    return(glycoform)
+  }
+  if (is.null(coor)) {
+    coor <- .calculate_residue_coordinates(structure)
+  }
+
   for (i in c(which(glycoform == 'Fuc'))) {
-    if (
-      !.is_reducing_end(structure, i) &&
-        .fucose_branch_y_offsets(structure, i) > 0
-    ) {
-      glycoform[i] <- 'FucUp'
+    if (!.is_reducing_end(structure, i)) {
+      glycoform[i] <- .fucose_directional_glycoform(structure, coor, i)
     }
   }
   return(glycoform)
+}
+
+#' Get directional Fuc shape name from rendered linkage direction
+#'
+#' @param structure An igraph glycan graph.
+#' @param coor A numeric coordinate matrix with rendered columns `x` and `y`.
+#' @param fuc_pos A single integer vertex index whose residue is Fuc.
+#'
+#' @returns A Fuc glycoform string: `"Fuc"` points up, `"FucUp"` points down,
+#'   `"FucRight"` points right, and `"FucLeft"` points left.
+#' @noRd
+.fucose_directional_glycoform <- function(structure, coor, fuc_pos) {
+  parent_pos <- as.integer(igraph::neighbors(structure, fuc_pos, mode = "in"))
+  if (length(parent_pos) == 0) {
+    return("Fuc")
+  }
+
+  linkage_vec <- coor[parent_pos[1], c("x", "y")] - coor[fuc_pos, c("x", "y")]
+  if (abs(linkage_vec[["x"]]) > abs(linkage_vec[["y"]])) {
+    if (linkage_vec[["x"]] > 0) {
+      return("FucRight")
+    }
+    return("FucLeft")
+  }
+  if (linkage_vec[["y"]] < 0) {
+    return("FucUp")
+  }
+  "Fuc"
 }

--- a/R/internal-data.R
+++ b/R/internal-data.R
@@ -64,6 +64,8 @@ glycan_dict <- list(
   '6dTal' = c('dHex', 'glyLightBlue'),
   'Fuc' = c('dHex', 'glyRed'),
   'FucUp' = c('dHexUp', 'glyRed'),
+  'FucRight' = c('dHexRight', 'glyRed'),
+  'FucLeft' = c('dHexLeft', 'glyRed'),
 
   'dHexNAc' = c('dHexNAc', 'glyWhite', 'glyWhite'),
   'QuiNAc' = c('dHexNAc', 'glyBlue', 'glyWhite'),
@@ -136,6 +138,14 @@ glycan_shape <- list(
   'dHexUp' = data.frame(
     x = c(-1, 0, 1, -1),
     y = c(0.33 * sqrt(3), -0.67 * sqrt(3), 0.33 * sqrt(3), 0.33 * sqrt(3))
+  ),
+  'dHexRight' = data.frame(
+    x = c(-0.33 * sqrt(3), 0.67 * sqrt(3), -0.33 * sqrt(3), -0.33 * sqrt(3)),
+    y = c(1, 0, -1, 1)
+  ),
+  'dHexLeft' = data.frame(
+    x = c(0.33 * sqrt(3), -0.67 * sqrt(3), 0.33 * sqrt(3), 0.33 * sqrt(3)),
+    y = c(1, 0, -1, 1)
   ),
   'dHexNAc' = data.frame(
     x = c(0, 1, 0, 0),

--- a/man/draw_cartoon.Rd
+++ b/man/draw_cartoon.Rd
@@ -9,6 +9,7 @@ draw_cartoon(
   ...,
   show_linkage = TRUE,
   orient = c("H", "V"),
+  fuc_orient = c("flex", "up"),
   red_end = "",
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
@@ -27,6 +28,11 @@ TRUE. Substituent annotations are always shown.}
 
 \item{orient}{The orientation of glycan structure. "H" for horizontal, "V" for vertical.
 Default is "H"}
+
+\item{fuc_orient}{Fuc triangle orientation. \code{"flex"} points non-reducing Fuc
+residues toward their rendered linkage direction, while \code{"up"} draws all
+Fuc triangles pointing upward. Reducing-end Fuc residues always point
+upward. Defaults to \code{"flex"}.}
 
 \item{red_end}{Reducing-end annotation. The default \code{""} keeps the current
 reducing-end line. Use \code{"~"} to add a wavy reducing end, or any other

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -13,6 +13,7 @@ export_cartoons(
   scale = 1,
   show_linkage = TRUE,
   orient = c("H", "V"),
+  fuc_orient = c("flex", "up"),
   red_end = "",
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
@@ -40,6 +41,11 @@ TRUE. Substituent annotations are always shown.}
 
 \item{orient}{The orientation of glycan structure. "H" for horizontal, "V" for vertical.
 Default is "H"}
+
+\item{fuc_orient}{Fuc triangle orientation. \code{"flex"} points non-reducing Fuc
+residues toward their rendered linkage direction, while \code{"up"} draws all
+Fuc triangles pointing upward. Reducing-end Fuc residues always point
+upward. Defaults to \code{"flex"}.}
 
 \item{red_end}{Reducing-end annotation. The default \code{""} keeps the current
 reducing-end line. Use \code{"~"} to add a wavy reducing end, or any other

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -1,3 +1,29 @@
+fuc_triangle_polygons <- function(plot) {
+  nodes <- ggplot2::ggplot_build(plot)$data[[3]]
+  polygons <- split(nodes[, c("x", "y")], nodes$group)
+  purrr::keep(polygons, ~ nrow(.x) == 4)
+}
+
+has_triangle_apex <- function(polygon, center, direction) {
+  vertices <- unique(polygon)
+  switch(
+    direction,
+    up = any(
+      abs(vertices$x - center[["x"]]) < 1e-6 & vertices$y > center[["y"]]
+    ),
+    down = any(
+      abs(vertices$x - center[["x"]]) < 1e-6 & vertices$y < center[["y"]]
+    ),
+    right = any(
+      vertices$x > center[["x"]] & abs(vertices$y - center[["y"]]) < 1e-6
+    ),
+    left = any(
+      vertices$x < center[["x"]] & abs(vertices$y - center[["y"]]) < 1e-6
+    ),
+    stop("Unknown direction: ", direction)
+  )
+}
+
 test_that("draw_cartoon works with valid branched glycan structure", {
   structure <- "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
 
@@ -391,6 +417,39 @@ test_that("draw_cartoon places a1-6 core Fuc up and a1-3 core Fuc down", {
   expect_lt(min(fuc_segments$yend), -0.5)
 })
 
+test_that("draw_cartoon controls Fuc triangle orientation", {
+  structure <- "Fuc(a1-3)[Fuc(a1-6)]GlcNAc(b1-4)GlcNAc(b1-"
+
+  flex_plot <- draw_cartoon(structure, fuc_orient = "flex")
+  up_plot <- draw_cartoon(structure, fuc_orient = "up")
+  flex_fuc <- fuc_triangle_polygons(flex_plot)
+  up_fuc <- fuc_triangle_polygons(up_plot)
+
+  expect_true(has_triangle_apex(flex_fuc[[1]], c(x = -1, y = -1), "up"))
+  expect_true(has_triangle_apex(flex_fuc[[2]], c(x = -1, y = 1), "down"))
+  expect_true(has_triangle_apex(up_fuc[[1]], c(x = -1, y = -1), "up"))
+  expect_true(has_triangle_apex(up_fuc[[2]], c(x = -1, y = 1), "up"))
+})
+
+test_that("draw_cartoon points vertical Fuc triangles toward their linkage", {
+  structure <- "Fuc(a1-3)[Fuc(a1-6)]GlcNAc(b1-4)GlcNAc(b1-"
+
+  plot <- draw_cartoon(structure, orient = "V", fuc_orient = "flex")
+  fuc <- fuc_triangle_polygons(plot)
+
+  expect_true(has_triangle_apex(fuc[[1]], c(x = -1, y = 1), "right"))
+  expect_true(has_triangle_apex(fuc[[2]], c(x = 1, y = 1), "left"))
+})
+
+test_that("draw_cartoon keeps reducing-end Fuc triangles up", {
+  structure <- "GlcNAc(b1-3)Fuc(a1-"
+
+  plot <- draw_cartoon(structure, orient = "V", fuc_orient = "flex")
+  fuc <- fuc_triangle_polygons(plot)
+
+  expect_true(has_triangle_apex(fuc[[1]], c(x = 0, y = 0), "up"))
+})
+
 test_that(".calculate_residue_coordinates keeps same-column residues at least one unit apart", {
   structure <- .as_single_glycan_structure(
     "Fuc(a1-3)[Fuc(a1-6)]GlcNAc(b1-4)GlcNAc(b1-"
@@ -602,6 +661,21 @@ test_that("export_cartoons forwards custom node sizes", {
     1.2,
     tolerance = 1e-6
   )
+})
+
+test_that("export_cartoons forwards custom Fuc orientation", {
+  glycans <- "Fuc(a1-3)[Fuc(a1-6)]GlcNAc(b1-4)GlcNAc(b1-"
+  temp_dir <- tempfile()
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+  fs::dir_create(temp_dir)
+
+  suppressMessages(
+    result <- export_cartoons(glycans, temp_dir, fuc_orient = "up")
+  )
+  fuc <- fuc_triangle_polygons(result[[1]])
+
+  expect_true(has_triangle_apex(fuc[[1]], c(x = -1, y = -1), "up"))
+  expect_true(has_triangle_apex(fuc[[2]], c(x = -1, y = 1), "up"))
 })
 
 test_that("export_cartoons rejects node_size values that make residues overlap", {


### PR DESCRIPTION
## Summary
- Add `fuc_orient = c("flex", "up")` to `draw_cartoon()` and `export_cartoons()`.
- Keep the default `"flex"` behavior aligned to rendered linkage direction, including left/right Fuc triangles for vertical glycans.
- Keep reducing-end O-Fuc triangles upward and document the new argument.

## Verification
- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::test(filter = "glydraw")'` — 145 passed, 0 failed
- `Rscript -e 'devtools::test()'` — 151 passed, 0 failed
- `git diff --check`

Closes #38