### PR TITLE
fix: handle orientation-specific HexNAc offsets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 
 * Deprecate `dpi` for `save_cartoon()` and `export_cartoons()` because glydraw uses an internal fixed design scale. Supplying `dpi` now warns that the argument is ignored. (#35)
 * Keep substituent annotations visible when `show_linkage = FALSE`. (#41)
+* Fix diagonal HexNAc linkage annotation offsets when `orient = "V"`. (#43)
 * Adjust linkage annotation offsets for diagonal HexNAc links. (#29)
 
 # glydraw 0.5.1

--- a/R/internal-annotations.R
+++ b/R/internal-annotations.R
@@ -131,6 +131,7 @@
 #'   of the linkage.
 #' @param role Either `"child"` or `"parent"`, naming which side of the linkage
 #'   the label belongs to.
+#' @param orient Drawing orientation, either `"H"` or `"V"`.
 #'
 #' @returns A numeric scalar offset distance from the anchor residue center.
 #' @noRd
@@ -141,24 +142,62 @@
   anchor_y,
   other_x,
   other_y,
-  role = c("child", "parent")
+  role = c("child", "parent"),
+  orient = c("H", "V")
 ) {
   role <- rlang::arg_match(role)
+  orient <- rlang::arg_match(orient)
   base_offset <- 0.4
   diagonal_hexnac_offset <- 0.45
   mono <- igraph::V(structure)[[anchor_ver]]$mono
   glycoform <- glycan_dict[[mono]][[1]]
-  needs_extra_offset <- if (role == "child") {
-    other_x > anchor_x && anchor_y > other_y
-  } else {
-    other_x < anchor_x && other_y < anchor_y
-  }
+  needs_extra_offset <- .needs_diagonal_hexnac_offset(
+    anchor_x,
+    anchor_y,
+    other_x,
+    other_y,
+    role,
+    orient
+  )
 
   if (identical(glycoform, "HexNAc") && needs_extra_offset) {
     return(diagonal_hexnac_offset)
   }
 
   base_offset
+}
+
+#' Check whether a diagonal HexNAc label needs extra clearance
+#'
+#' @param anchor_x,anchor_y Numeric coordinates of the residue receiving the
+#'   label.
+#' @param other_x,other_y Numeric coordinates of the residue on the other side
+#'   of the linkage.
+#' @param role Either `"child"` or `"parent"`, naming which side of the linkage
+#'   the label belongs to.
+#' @param orient Drawing orientation, either `"H"` or `"V"`.
+#'
+#' @returns A logical scalar.
+#' @noRd
+.needs_diagonal_hexnac_offset <- function(
+  anchor_x,
+  anchor_y,
+  other_x,
+  other_y,
+  role,
+  orient
+) {
+  if (orient == "H") {
+    if (role == "child") {
+      return(other_x > anchor_x && other_y < anchor_y)
+    }
+    return(other_x < anchor_x && other_y < anchor_y)
+  }
+
+  if (role == "child") {
+    return(other_x < anchor_x && other_y < anchor_y)
+  }
+  other_x < anchor_x && other_y > anchor_y
 }
 
 #' Build linkage annotation rows for every glycosidic edge
@@ -168,20 +207,35 @@
 #'   per graph vertex.
 #' @param node_size Numeric node-size multiplier used to keep labels outside
 #'   scaled residue polygons.
+#' @param orient Drawing orientation, either `"H"` or `"V"`.
 #'
 #' @returns A data frame with one or two rows per edge and columns `vertice`,
 #'   `annot`, `x`, `y`, `segment_start_x`, `segment_start_y`, `segment_end_x`,
 #'   and `segment_end_y`. `annot` contains normalized labels such as `alpha`,
 #'   `beta`, or linkage position text.
 #' @noRd
-.linkage_annotation_data <- function(structure, coor, node_size = 1) {
+.linkage_annotation_data <- function(
+  structure,
+  coor,
+  node_size = 1,
+  orient = c("H", "V")
+) {
   if (igraph::ecount(structure) == 0) {
     return(.empty_linkage_annotation_data())
   }
+  orient <- rlang::arg_match(orient)
 
   annotation <- purrr::map_dfr(
     seq_len(length(structure) - 1),
-    \(ver) .linkage_annotation_rows(structure, coor, ver, node_size = node_size)
+    \(ver) {
+      .linkage_annotation_rows(
+        structure,
+        coor,
+        ver,
+        node_size = node_size,
+        orient = orient
+      )
+    }
   )
   annotation$annot <- .normalize_linkage_labels(annotation$annot)
   annotation
@@ -215,19 +269,28 @@
 #' @param ver A single integer child vertex index.
 #' @param node_size Numeric node-size multiplier used to keep labels outside
 #'   scaled residue polygons.
+#' @param orient Drawing orientation, either `"H"` or `"V"`.
 #'
 #' @returns A two-row data frame with linkage annotation columns. The first row
 #'   is the child-side anomer label and the second row is the parent-side
 #'   linkage-position label.
 #' @noRd
-.linkage_annotation_rows <- function(structure, coor, ver, node_size = 1) {
+.linkage_annotation_rows <- function(
+  structure,
+  coor,
+  ver,
+  node_size = 1,
+  orient = c("H", "V")
+) {
+  orient <- rlang::arg_match(orient)
   par_ver <- .parent_vertex_for_annotation(structure, ver)
   labels <- strsplit(igraph::E(structure)[ver]$linkage, '-')[[1]]
   offsets <- .linkage_label_offsets(
     structure,
     coor,
-    ver,
-    par_ver
+    child_ver = ver,
+    parent_ver = par_ver,
+    orient = orient
   )
   label_positions <- .linkage_label_positions(
     coor[ver, "x"],
@@ -283,11 +346,19 @@
 #'   per graph vertex.
 #' @param child_ver A single integer child vertex index.
 #' @param parent_ver A single integer parent vertex index.
+#' @param orient Drawing orientation, either `"H"` or `"V"`.
 #'
 #' @returns A named numeric vector with values `child` and `parent`, giving the
 #'   distance from each residue center to its label.
 #' @noRd
-.linkage_label_offsets <- function(structure, coor, child_ver, parent_ver) {
+.linkage_label_offsets <- function(
+  structure,
+  coor,
+  child_ver,
+  parent_ver,
+  orient = c("H", "V")
+) {
+  orient <- rlang::arg_match(orient)
   c(
     child = .linkage_label_offset(
       structure,
@@ -296,7 +367,8 @@
       coor[child_ver, "y"],
       coor[parent_ver, "x"],
       coor[parent_ver, "y"],
-      role = "child"
+      role = "child",
+      orient = orient
     ),
     parent = .linkage_label_offset(
       structure,
@@ -305,7 +377,8 @@
       coor[parent_ver, "y"],
       coor[child_ver, "x"],
       coor[child_ver, "y"],
-      role = "parent"
+      role = "parent",
+      orient = orient
     )
   )
 }

--- a/R/internal-cartoon.R
+++ b/R/internal-cartoon.R
@@ -208,7 +208,8 @@
   linkage_annotation <- .linkage_annotation_data(
     structure,
     coor,
-    node_size = node_size
+    node_size = node_size,
+    orient = orient
   ) |>
     dplyr::mutate(show_without_linkage = FALSE)
   substituent_annotation <- .substituent_annotation_data(

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -132,6 +132,101 @@ test_that("draw_cartoon moves linkage annotations along the line for larger node
   expect_lt(custom_three$x, default_three$x)
 })
 
+test_that("linkage annotation offsets follow orientation-specific HexNAc corners", {
+  structure <- igraph::make_empty_graph(n = 1)
+  igraph::V(structure)$mono <- "GlcNAc"
+
+  h_child_right_bottom_offset <- .linkage_label_offset(
+    structure,
+    anchor_ver = 1,
+    anchor_x = 0,
+    anchor_y = 0,
+    other_x = 1,
+    other_y = -1,
+    role = "child",
+    orient = "H"
+  )
+  h_parent_left_bottom_offset <- .linkage_label_offset(
+    structure,
+    anchor_ver = 1,
+    anchor_x = 0,
+    anchor_y = 0,
+    other_x = -1,
+    other_y = -1,
+    role = "parent",
+    orient = "H"
+  )
+  h_child_right_top_offset <- .linkage_label_offset(
+    structure,
+    anchor_ver = 1,
+    anchor_x = 0,
+    anchor_y = 0,
+    other_x = 1,
+    other_y = 1,
+    role = "child",
+    orient = "H"
+  )
+  h_parent_left_top_offset <- .linkage_label_offset(
+    structure,
+    anchor_ver = 1,
+    anchor_x = 0,
+    anchor_y = 0,
+    other_x = -1,
+    other_y = 1,
+    role = "parent",
+    orient = "H"
+  )
+  child_left_down_offset <- .linkage_label_offset(
+    structure,
+    anchor_ver = 1,
+    anchor_x = 0.5,
+    anchor_y = 1,
+    other_x = 0,
+    other_y = 0,
+    role = "child",
+    orient = "V"
+  )
+  parent_left_up_offset <- .linkage_label_offset(
+    structure,
+    anchor_ver = 1,
+    anchor_x = 0,
+    anchor_y = 0,
+    other_x = -0.5,
+    other_y = 1,
+    role = "parent",
+    orient = "V"
+  )
+  child_right_down_offset <- .linkage_label_offset(
+    structure,
+    anchor_ver = 1,
+    anchor_x = -0.5,
+    anchor_y = 1,
+    other_x = 0,
+    other_y = 0,
+    role = "child",
+    orient = "V"
+  )
+  parent_right_up_offset <- .linkage_label_offset(
+    structure,
+    anchor_ver = 1,
+    anchor_x = 0,
+    anchor_y = 0,
+    other_x = 0.5,
+    other_y = 1,
+    role = "parent",
+    orient = "V"
+  )
+
+  expect_equal(h_child_right_bottom_offset, 0.45)
+  expect_equal(h_parent_left_bottom_offset, 0.45)
+  expect_equal(h_child_right_top_offset, 0.4)
+  expect_equal(h_parent_left_top_offset, 0.4)
+  expect_equal(child_left_down_offset, 0.45)
+  expect_equal(parent_left_up_offset, 0.45)
+  expect_equal(child_right_down_offset, 0.4)
+  expect_equal(parent_right_up_offset, 0.4)
+})
+
 test_that("draw_cartoon warns and hides linkage annotations for oversized nodes", {
   structure <- "Gal(b1-3)GalNAc(a1-"
 


### PR DESCRIPTION
## Summary
- Keep the existing horizontal HexNAc diagonal offset behavior limited to right-bottom child labels and left-bottom parent labels.
- Add vertical-orientation HexNAc offset handling for left-down child labels and left-up parent labels.
- Add regression coverage for adjusted and non-adjusted corners in both orientations.

## NEWS
- Fix diagonal HexNAc linkage annotation offsets when `orient = "V"`. (#43)

## Verification
- `Rscript -e 'devtools::document()'`
- `air format R/internal-annotations.R R/internal-cartoon.R tests/testthat/test-glydraw.R`
- `Rscript -e 'devtools::test()'` — 159 passed, 0 failed