### PR TITLE
Add custom monosaccharide colors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 
 ## New features
 
+* Add the `colors` parameter to `draw_cartoon()` and `export_cartoons()` for customizing monosaccharide fill colors.
 * Add the `fuc_orient` parameter to `draw_cartoon()` and `export_cartoons()` for choosing whether Fuc triangles always point upward or flex toward their linkage direction. (#42)
 * Add the `scale` parameter to `save_cartoon()` and `export_cartoons()` for changing output pixel dimensions while preserving cartoon appearance. (#35)
 * Add the `node_size` parameter to `draw_cartoon()` and `export_cartoons()` for scaling residue cartoon sizes. Values larger than `2` are rejected because residues overlap. (#36)

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 ## New features
 
-* Add the `colors` parameter to `draw_cartoon()` and `export_cartoons()` for customizing monosaccharide fill colors.
+* Add the `colors` parameter to `draw_cartoon()` and `export_cartoons()` for customizing monosaccharide fill colors. (#44)
 * Add the `fuc_orient` parameter to `draw_cartoon()` and `export_cartoons()` for choosing whether Fuc triangles always point upward or flex toward their linkage direction. (#42)
 * Add the `scale` parameter to `save_cartoon()` and `export_cartoons()` for changing output pixel dimensions while preserving cartoon appearance. (#35)
 * Add the `node_size` parameter to `draw_cartoon()` and `export_cartoons()` for scaling residue cartoon sizes. Values larger than `2` are rejected because residues overlap. (#36)

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -23,6 +23,10 @@
 #'   are moved farther from larger nodes, and are hidden with a warning when
 #'   `node_size` is too large to leave enough annotation space. Values larger
 #'   than `2` are rejected because residues overlap.
+#' @param colors Optional named character vector of custom monosaccharide fill
+#'   colors. Names must be supported monosaccharide names, such as `"Gal"` or
+#'   `"GlcNAc"`. User-provided colors overwrite the default SNFG colors, while
+#'   unprovided monosaccharides keep their default colors. Defaults to `NULL`.
 #' @param highlight An integer vector specifying the node indices to highlight.
 #'   This argument is applicable only when `structure` is a [glyrepr::glycan_structure()].
 #'   Note that for a [glyrepr::glycan_structure()], the node indices correspond exactly
@@ -46,11 +50,13 @@ draw_cartoon <- function(
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
   node_size = 1,
+  colors = NULL,
   highlight = NULL
 ) {
   checkmate::assert_number(edge_linewidth, lower = 0)
   checkmate::assert_number(node_linewidth, lower = 0)
   .validate_node_size(node_size)
+  colors <- .validate_custom_colors(colors)
   fuc_orient <- rlang::arg_match(fuc_orient)
   inputs <- .prepare_cartoon_inputs(structure, highlight, orient, red_end)
   structure <- inputs$structure
@@ -64,7 +70,7 @@ draw_cartoon <- function(
     gly_list,
     .default_node_point_size * node_size
   )
-  filled_color <- glycan_color[as.character(polygon_coor$color)]
+  filled_color <- .resolve_residue_fill_colors(polygon_coor, colors)
   annotation_data <- .cartoon_text_annotation_data(
     structure,
     coor,
@@ -239,9 +245,11 @@ export_cartoons <- function(
   red_end = "",
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
-  node_size = 1
+  node_size = 1,
+  colors = NULL
 ) {
   .validate_node_size(node_size)
+  colors <- .validate_custom_colors(colors)
   fuc_orient <- rlang::arg_match(fuc_orient)
   if (!missing(dpi)) {
     .warn_ignored_dpi()
@@ -264,7 +272,8 @@ export_cartoons.character <- function(
   red_end = "",
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
-  node_size = 1
+  node_size = 1,
+  colors = NULL
 ) {
   glycans <- unique(.as_glycan_structure_input(x))
   .export_cartoon_list(
@@ -278,7 +287,8 @@ export_cartoons.character <- function(
     red_end = red_end,
     edge_linewidth = edge_linewidth,
     node_linewidth = node_linewidth,
-    node_size = node_size
+    node_size = node_size,
+    colors = colors
   )
 }
 
@@ -296,7 +306,8 @@ export_cartoons.glyrepr_structure <- function(
   red_end = "",
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
-  node_size = 1
+  node_size = 1,
+  colors = NULL
 ) {
   glycans <- unique(x)
   .export_cartoon_list(
@@ -310,7 +321,8 @@ export_cartoons.glyrepr_structure <- function(
     red_end = red_end,
     edge_linewidth = edge_linewidth,
     node_linewidth = node_linewidth,
-    node_size = node_size
+    node_size = node_size,
+    colors = colors
   )
 }
 
@@ -329,6 +341,8 @@ export_cartoons.glyrepr_structure <- function(
 #' @param node_linewidth Numeric node border line width passed to
 #'   `draw_cartoon()`.
 #' @param node_size Numeric node size multiplier passed to `draw_cartoon()`.
+#' @param colors Optional custom monosaccharide colors passed to
+#'   `draw_cartoon()`.
 #'
 #' @return A list of `glydraw_cartoon` objects, invisibly. Files are written to
 #'   `dirname` with sanitized labels and extension `file_ext`.
@@ -344,9 +358,11 @@ export_cartoons.glyrepr_structure <- function(
   red_end,
   edge_linewidth,
   node_linewidth,
-  node_size
+  node_size,
+  colors
 ) {
   .validate_node_size(node_size)
+  colors <- .validate_custom_colors(colors)
   fuc_orient <- rlang::arg_match(fuc_orient, c("flex", "up"))
   cli::cli_alert_info("Exporting {.val {length(glycans)}} glycan cartoons.")
   fs::dir_create(dirname)
@@ -360,7 +376,8 @@ export_cartoons.glyrepr_structure <- function(
     red_end = red_end,
     edge_linewidth = edge_linewidth,
     node_linewidth = node_linewidth,
-    node_size = node_size
+    node_size = node_size,
+    colors = colors
   )
   filenames <- fs::path(
     dirname,

--- a/R/internal-cartoon.R
+++ b/R/internal-cartoon.R
@@ -44,25 +44,101 @@
   FALSE
 }
 
+#' Validate custom monosaccharide colors
+#'
+#' @param colors `NULL` or a named character vector of color values.
+#'
+#' @returns A named character vector of custom colors.
+#' @noRd
+.validate_custom_colors <- function(colors = NULL) {
+  if (is.null(colors)) {
+    return(character())
+  }
+
+  checkmate::assert_character(colors, any.missing = FALSE)
+  if (length(colors) == 0) {
+    return(character())
+  }
+
+  color_names <- names(colors)
+  if (
+    is.null(color_names) ||
+      anyNA(color_names) ||
+      any(color_names == "") ||
+      anyDuplicated(color_names)
+  ) {
+    cli::cli_abort(
+      "{.arg colors} must be a character vector with unique, non-empty names."
+    )
+  }
+
+  supported_monosaccharides <- .supported_color_monosaccharides()
+  invalid_names <- setdiff(color_names, supported_monosaccharides)
+  if (length(invalid_names) > 0) {
+    cli::cli_abort(c(
+      "{.arg colors} must be named with supported monosaccharides.",
+      "x" = "Unsupported {cli::qty(invalid_names)} name{?s}: {.val {invalid_names}}."
+    ))
+  }
+
+  invisible(colors)
+}
+
+#' Get monosaccharide names accepted by custom colors
+#'
+#' @returns A character vector of supported public monosaccharide names.
+#' @noRd
+.supported_color_monosaccharides <- function() {
+  setdiff(names(glycan_dict), c("FucUp", "FucRight", "FucLeft"))
+}
+
+#' Resolve polygon fill colors
+#'
+#' @param polygon_coor A data frame returned by `.residue_polygon_data()`.
+#' @param colors A named character vector returned by `.validate_custom_colors()`.
+#'
+#' @returns A character vector of polygon fill colors, one value per row in
+#'   `polygon_coor`.
+#' @noRd
+.resolve_residue_fill_colors <- function(polygon_coor, colors = character()) {
+  default_colors <- glycan_color[as.character(polygon_coor$color)]
+  if (length(colors) == 0) {
+    return(unname(default_colors))
+  }
+
+  custom_colors <- colors[as.character(polygon_coor$mono)]
+  has_custom_color <- !is.na(custom_colors)
+  default_colors[has_custom_color] <- custom_colors[has_custom_color]
+  unname(default_colors)
+}
+
 #' Convert residue centers to polygon vertices
 #'
 #' @param gly_list A data frame with columns `center_x`, `center_y`,
-#'   `glycoform`, and `transparency`, usually from `.cartoon_residue_data()`.
+#'   `mono`, `glycoform`, and `transparency`, usually from
+#'   `.cartoon_residue_data()`.
 #' @param point_size Numeric scale factor for SNFG shape templates.
 #'
-#' @returns A data frame with columns `point_x`, `point_y`, `group`, `color`,
-#'   and `alpha`. Multi-part residue shapes contribute multiple groups.
+#' @returns A data frame with columns `point_x`, `point_y`, `group`, `mono`,
+#'   `color`, and `alpha`. Multi-part residue shapes contribute multiple groups.
 #' @noRd
 .residue_polygon_data <- function(gly_list, point_size) {
   # Progressively read and process lines in gly_list
   polygon_coor <- gly_list |>
-    purrr::pmap_dfr(function(center_x, center_y, glycoform, transparency) {
+    purrr::pmap_dfr(function(
+      center_x,
+      center_y,
+      mono,
+      glycoform,
+      transparency
+    ) {
       composition <- glycan_dict[[glycoform]][1] # Mapping the Composition of Glycoform, e.g.'Fuc'->'dHex'
       df1 <- data.frame(
         point_x = c(point_size * glycan_shape[[composition]]$x + center_x),
         point_y = c(point_size * glycan_shape[[composition]]$y + center_y),
         # For Distinguishing the Coordinates of each point
         group = paste0(glycoform, center_x, "_", center_y),
+        mono = mono,
         color = glycan_dict[[glycoform]][2],
         alpha = transparency
       )
@@ -72,6 +148,7 @@
           point_y = c(point_size * glycan_shape[[composition]]$yy + center_y),
           # For Distinguishing the Coordinates of each point
           group = paste0(glycoform, center_x, "_", center_y, 'remain'),
+          mono = mono,
           color = glycan_dict[[glycoform]][3],
           alpha = transparency
         )
@@ -165,6 +242,7 @@
   fuc_orient <- rlang::arg_match(fuc_orient)
   gly_list <- data.frame(
     coor,
+    mono = igraph::V(structure)$mono,
     glycoform = .residue_glycoforms(structure, coor, fuc_orient)
   )
   if (!is.null(highlight)) {
@@ -176,7 +254,13 @@
   } else {
     gly_list$transparency <- 1.0
   }
-  colnames(gly_list) <- c("center_x", "center_y", "glycoform", "transparency")
+  colnames(gly_list) <- c(
+    "center_x",
+    "center_y",
+    "mono",
+    "glycoform",
+    "transparency"
+  )
   gly_list
 }
 

--- a/man/draw_cartoon.Rd
+++ b/man/draw_cartoon.Rd
@@ -14,6 +14,7 @@ draw_cartoon(
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
   node_size = 1,
+  colors = NULL,
   highlight = NULL
 )
 }
@@ -49,6 +50,11 @@ size. Defaults to \code{1}, which keeps the current size. Linkage annotations
 are moved farther from larger nodes, and are hidden with a warning when
 \code{node_size} is too large to leave enough annotation space. Values larger
 than \code{2} are rejected because residues overlap.}
+
+\item{colors}{Optional named character vector of custom monosaccharide fill
+colors. Names must be supported monosaccharide names, such as \code{"Gal"} or
+\code{"GlcNAc"}. User-provided colors overwrite the default SNFG colors, while
+unprovided monosaccharides keep their default colors. Defaults to \code{NULL}.}
 
 \item{highlight}{An integer vector specifying the node indices to highlight.
 This argument is applicable only when \code{structure} is a \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}}.

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -17,7 +17,8 @@ export_cartoons(
   red_end = "",
   edge_linewidth = 0.8,
   node_linewidth = 0.8,
-  node_size = 1
+  node_size = 1,
+  colors = NULL
 )
 }
 \arguments{
@@ -62,6 +63,11 @@ size. Defaults to \code{1}, which keeps the current size. Linkage annotations
 are moved farther from larger nodes, and are hidden with a warning when
 \code{node_size} is too large to leave enough annotation space. Values larger
 than \code{2} are rejected because residues overlap.}
+
+\item{colors}{Optional named character vector of custom monosaccharide fill
+colors. Names must be supported monosaccharide names, such as \code{"Gal"} or
+\code{"GlcNAc"}. User-provided colors overwrite the default SNFG colors, while
+unprovided monosaccharides keep their default colors. Defaults to \code{NULL}.}
 }
 \value{
 The function returns the list of cartoons implicitly.

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -73,6 +73,25 @@ test_that("draw_cartoon controls edge and node linewidths", {
   expect_equal(unique(custom_layers[[5]]$linewidth), 1.2)
 })
 
+test_that("draw_cartoon applies custom monosaccharide colors over defaults", {
+  structure <- "Gal(b1-4)GlcNAc(b1-"
+
+  plot <- draw_cartoon(structure, colors = c(Gal = "#123456"))
+  node_fill <- unique(ggplot2::ggplot_build(plot)$data[[3]]$fill)
+
+  expect_contains(node_fill, "#123456")
+  expect_contains(node_fill, "#0072BC")
+})
+
+test_that("draw_cartoon rejects unsupported custom color names", {
+  structure <- "Gal(b1-4)GlcNAc(b1-"
+
+  expect_error(
+    draw_cartoon(structure, colors = c(NotAMono = "#123456")),
+    "supported monosaccharides"
+  )
+})
+
 test_that("draw_cartoon scales node polygons with node_size", {
   structure <- "Gal(b1-3)GalNAc(a1-"
 
@@ -719,6 +738,25 @@ test_that("export_cartoons forwards custom linewidths", {
 
   expect_equal(unique(layers[[1]]$linewidth), 1.1)
   expect_equal(unique(layers[[3]]$linewidth), 0.3)
+})
+
+test_that("export_cartoons forwards custom colors", {
+  glycans <- "Gal(b1-4)GlcNAc(b1-"
+  temp_dir <- tempfile()
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+  fs::dir_create(temp_dir)
+
+  suppressMessages(
+    result <- export_cartoons(
+      glycans,
+      temp_dir,
+      colors = c(Gal = "#123456")
+    )
+  )
+  node_fill <- unique(ggplot2::ggplot_build(result[[1]])$data[[3]]$fill)
+
+  expect_contains(node_fill, "#123456")
+  expect_contains(node_fill, "#0072BC")
 })
 
 test_that("export_cartoons forwards custom node sizes", {


### PR DESCRIPTION
## Summary
Add a `colors` argument to `draw_cartoon()` and `export_cartoons()` so users can override SNFG fill colors for named monosaccharides while preserving defaults for unprovided residues.

## Details
- Adds validation for custom color vectors, requiring unique non-empty names that match supported monosaccharides.
- Resolves residue fill colors by applying user-provided monosaccharide colors over the default SNFG color table.
- Forwards `colors` through `export_cartoons()` for character and `glyrepr_structure` inputs.
- Updates roxygen-generated documentation and adds tests for color overrides, invalid names, and export forwarding.

## Verification
- `Rscript -e 'devtools::document()'`
- `git diff --check`
- `Rscript -e 'devtools::load_all(); devtools::test(filter = "glydraw")'` [158 passed]
- `Rscript -e 'devtools::load_all(); devtools::test()'` [164 passed]
- `air format R/glydraw.R R/internal-cartoon.R tests/testthat/test-glydraw.R`