### PR TITLE
Extend Fuc-like residue layout

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 
 ## Minor improvements and bug fixes
 
+* Extend Fuc-style branch layout and flexible orientation to additional Fuc-like residues. (#46)
 * Fix `draw_cartoon()` for structures with two core Fuc branches and one b1-4 GlcNAc branch, avoiding an igraph vertex-selection error and keeping the b1-4 GlcNAc aligned with the core GlcNAc. (#45)
 * Deprecate `dpi` for `save_cartoon()` and `export_cartoons()` because glydraw uses an internal fixed design scale. Supplying `dpi` now warns that the argument is ignored. (#35)
 * Keep substituent annotations visible when `show_linkage = FALSE`. (#41)

--- a/R/glydraw.R
+++ b/R/glydraw.R
@@ -7,10 +7,10 @@
 #'   TRUE. Substituent annotations are always shown.
 #' @param orient The orientation of glycan structure. "H" for horizontal, "V" for vertical.
 #'   Default is "H"
-#' @param fuc_orient Fuc triangle orientation. `"flex"` points non-reducing Fuc
-#'   residues toward their rendered linkage direction, while `"up"` draws all
-#'   Fuc triangles pointing upward. Reducing-end Fuc residues always point
-#'   upward. Defaults to `"flex"`.
+#' @param fuc_orient Fuc-like triangle orientation. `"flex"` points
+#'   non-reducing Fuc-like residues toward their rendered linkage direction,
+#'   while `"up"` draws all Fuc-like triangles pointing upward. Reducing-end
+#'   Fuc-like residues always point upward. Defaults to `"flex"`.
 #' @param red_end Reducing-end annotation. The default `""` keeps the current
 #'   reducing-end line. Use `"~"` to add a wavy reducing end, or any other
 #'   string to draw that string at the reducing end.
@@ -334,7 +334,7 @@ export_cartoons.glyrepr_structure <- function(
 #' @param scale Numeric output-size multiplier passed to `save_cartoon()`.
 #' @param show_linkage Logical scalar passed to `draw_cartoon()`.
 #' @param orient Drawing orientation, either `"H"` or `"V"`.
-#' @param fuc_orient Fuc triangle orientation passed to `draw_cartoon()`.
+#' @param fuc_orient Fuc-like triangle orientation passed to `draw_cartoon()`.
 #' @param red_end String reducing-end annotation passed to `draw_cartoon()`.
 #' @param edge_linewidth Numeric linkage line width passed to
 #'   `draw_cartoon()`.

--- a/R/internal-cartoon.R
+++ b/R/internal-cartoon.R
@@ -89,7 +89,7 @@
 #' @returns A character vector of supported public monosaccharide names.
 #' @noRd
 .supported_color_monosaccharides <- function() {
-  setdiff(names(glycan_dict), c("FucUp", "FucRight", "FucLeft"))
+  setdiff(names(glycan_dict), .directional_fucose_like_glycoforms())
 }
 
 #' Resolve polygon fill colors
@@ -228,7 +228,7 @@
 #' @param coor A numeric coordinate matrix with columns `x` and `y`.
 #' @param highlight `NULL` or a numeric vector of 1-based vertex indices to
 #'   highlight.
-#' @param fuc_orient Fuc triangle orientation, either `"flex"` or `"up"`.
+#' @param fuc_orient Fuc-like triangle orientation, either `"flex"` or `"up"`.
 #'
 #' @returns A data frame with columns `center_x`, `center_y`, `glycoform`, and
 #'   `transparency`, one row per residue vertex.

--- a/R/internal-coordinates.R
+++ b/R/internal-coordinates.R
@@ -9,7 +9,7 @@
 #'
 #' @returns A numeric matrix with one row per vertex and columns `x` and `y`.
 #'   `x` is the negative graph distance from the reducing end, and `y` starts
-#'   at 0 except for preliminary Fuc subtree offsets.
+#'   at 0 except for preliminary Fuc-like subtree offsets.
 #' @noRd
 .initialize_residue_coordinates <- function(structure) {
   ver_num <- length(structure)
@@ -23,7 +23,8 @@
   coor[, 'x'] <- init_X
   for (i in seq(1, length(structure))) {
     if (
-      igraph::V(structure)[[i]]$mono == 'Fuc' && !.is_reducing_end(structure, i)
+      .is_fucose_like_layout_monosaccharide(igraph::V(structure)[[i]]$mono) &&
+        !.is_reducing_end(structure, i)
     ) {
       coor <- .shift_subtree_axis(structure, i, coor, "x", 1)
     }
@@ -87,17 +88,17 @@
   return(coor)
 }
 
-#' Rotate descendants of an elongated Fuc branch
+#' Rotate descendants of an elongated Fuc-like branch
 #'
 #' @param structure An igraph glycan graph.
-#' @param fuc_pos A single integer vertex index whose residue is Fuc.
+#' @param fuc_pos A single integer vertex index whose residue is Fuc-like.
 #' @param coor A numeric coordinate matrix with columns `x` and `y`.
-#' @param branch_offset A numeric vertical offset for the Fuc branch. Its sign
-#'   determines whether descendants rotate upward or downward.
+#' @param branch_offset A numeric vertical offset for the Fuc-like branch. Its
+#'   sign determines whether descendants rotate upward or downward.
 #'
 #' @returns The same coordinate matrix shape as `coor`, with descendants of
-#'   `fuc_pos` rotated around the Fuc coordinate. If the Fuc has no descendants
-#'   or the offset has no direction, `coor` is returned unchanged.
+#'   `fuc_pos` rotated around the Fuc-like coordinate. If the residue has no
+#'   descendants or the offset has no direction, `coor` is returned unchanged.
 #' @noRd
 .orient_fucose_branch_subtree <- function(
   structure,
@@ -128,11 +129,11 @@
   coor
 }
 
-#' Convert Fuc linkage positions to vertical branch offsets
+#' Convert Fuc-like linkage positions to vertical branch offsets
 #'
 #' @param structure An igraph glycan graph whose edge attributes include
 #'   `linkage`.
-#' @param fuc_pos An integer vector of Fuc vertex indices.
+#' @param fuc_pos An integer vector of Fuc-like vertex indices.
 #'
 #' @returns A numeric vector the same length as `fuc_pos`. Linkages ending in
 #'   `2` or `3` return `-1`; other linkage positions return `1`.
@@ -151,16 +152,16 @@
 #'   `linkage` and whose vertices include `mono`.
 #' @param ver A single integer vertex index.
 #'
-#' @returns An igraph vertex sequence of neighbors for `ver`, excluding Fuc
-#'   neighbors. Numeric linkage positions are sorted decreasing; unknown or
-#'   compound linkage values are placed at the bottom.
+#' @returns An igraph vertex sequence of neighbors for `ver`, excluding
+#'   Fuc-like neighbors. Numeric linkage positions are sorted decreasing;
+#'   unknown or compound linkage values are placed at the bottom.
 #'
 #' @noRd
 .order_child_vertices_by_linkage <- function(structure, ver) {
   neigh_pos <- igraph::neighbors(structure, ver) # Get neighbor vertices
-  fuc_pos <- neigh_pos[which(neigh_pos$mono == 'Fuc')]
+  fuc_pos <- neigh_pos[.is_fucose_like_layout_monosaccharide(neigh_pos$mono)]
   if (length(fuc_pos) != 0) {
-    neigh_pos <- neigh_pos[!neigh_pos %in% c(fuc_pos)] # Exclude Fucose in neighbor vertices
+    neigh_pos <- neigh_pos[!neigh_pos %in% c(fuc_pos)] # Exclude Fuc-like neighbor vertices
   }
   linkage_chars <- sub('.*-', '', igraph::E(structure)$linkage[neigh_pos])
   neigh_linkage <- suppressWarnings(as.numeric(linkage_chars))
@@ -207,15 +208,15 @@
   return(coor)
 }
 
-#' Spread non-Fuc child subtrees when a parent also has Fuc
+#' Spread non-Fuc-like child subtrees when a parent also has Fuc-like children
 #'
 #' @param coor A numeric coordinate matrix with columns `x` and `y`.
 #' @param structure An igraph glycan graph.
-#' @param ver A single integer parent vertex with Fuc and non-Fuc child
-#'   neighbors.
+#' @param ver A single integer parent vertex with Fuc-like and non-Fuc-like
+#'   child neighbors.
 #'
-#' @returns The same coordinate matrix shape as `coor`, with the two non-Fuc
-#'   child subtrees shifted to `+0.5` and `-0.5`.
+#' @returns The same coordinate matrix shape as `coor`, with the two
+#'   non-Fuc-like child subtrees shifted to `+0.5` and `-0.5`.
 #' @noRd
 .spread_non_fucose_children <- function(coor, structure, ver) {
   arrange_other_neigh_pos <- .order_child_vertices_by_linkage(structure, ver)
@@ -277,7 +278,7 @@
 #' @param min_gap A numeric minimum vertical gap in any shared `x` column.
 #'
 #' @returns A numeric vector with one vertical shift per layout. Shifts stay as
-#'   compact as possible while preserving anchored Fuc child positions.
+#'   compact as possible while preserving anchored Fuc-like child positions.
 #' @noRd
 .pack_child_subtree_layouts <- function(
   layouts,
@@ -316,8 +317,8 @@
   }
 
   # Fixed shifts are reserved for children whose rough-layout offset already
-  # carries semantic information. For now that means leaf Fuc children, whose
-  # a1-3/a1-6 linkages decide whether they sit below or above the parent.
+  # carries semantic information. For now that means leaf Fuc-like children,
+  # whose a1-3/a1-6 linkages decide whether they sit below or above the parent.
   shifts[fixed_shifts] <- as.numeric(preferred_shifts[fixed_shifts])
   shifts <- .apply_isolated_preferred_shifts(
     layouts,
@@ -633,15 +634,15 @@
 #' @param structure An igraph glycan graph whose vertices include `mono`.
 #' @param child_pos Integer vector of child vertex indices in bottom-to-top order.
 #'
-#' @returns A logical vector the same length as `child_pos`. Single-residue Fuc
-#'   children are anchored because their rough shift already encodes the
-#'   linkage-specific Fuc side.
+#' @returns A logical vector the same length as `child_pos`. Single-residue
+#'   Fuc-like children are anchored because their rough shift already encodes
+#'   the linkage-specific side.
 #' @noRd
 .fixed_child_subtree_shifts <- function(structure, child_pos) {
   purrr::map_lgl(child_pos, function(child) {
-    # Only leaf Fuc children are anchored. Elongated Fuc branches need normal
+    # Only leaf Fuc-like children are anchored. Elongated branches need normal
     # compaction because their descendants can create real subtree collisions.
-    igraph::V(structure)[[child]]$mono == "Fuc" &&
+    .is_fucose_like_layout_monosaccharide(igraph::V(structure)[[child]]$mono) &&
       length(igraph::neighbors(structure, child, mode = "out")) == 0
   })
 }
@@ -681,8 +682,8 @@
     \(child) .compact_subtree_coordinates(structure, child, coor, min_gap)
   )
   # Rough offsets choose branch side and ordering. The packer may use them as
-  # fixed positions for leaf Fuc children, but ordinary child subtrees still use
-  # the compact centered packing path.
+  # fixed positions for leaf Fuc-like children, but ordinary child subtrees
+  # still use the compact centered packing path.
   shifts <- .pack_child_subtree_layouts(
     layouts,
     preferred_shifts = rough_offsets,
@@ -748,8 +749,8 @@
 #' @param coor A numeric coordinate matrix with columns `x` and `y`.
 #'
 #' @returns The same coordinate matrix shape as `coor`, with two-child,
-#'   three-child, and Fuc-containing branch subtrees vertically spread before
-#'   final compaction.
+#'   three-child, and Fuc-like-containing branch subtrees vertically spread
+#'   before final compaction.
 #' @noRd
 .spread_rough_child_subtrees <- function(structure, coor) {
   for (ver in .reverse_vertex_order(structure)) {
@@ -770,9 +771,10 @@
 #' @noRd
 .spread_child_subtrees_for_vertex <- function(coor, structure, ver) {
   gly_neighbors <- igraph::neighbors(structure, ver)
-  has_fucose <- 'Fuc' %in% gly_neighbors$mono
+  is_fucose_like <- .is_fucose_like_layout_monosaccharide(gly_neighbors$mono)
+  has_fucose <- any(is_fucose_like)
   neighbor_num <- length(gly_neighbors)
-  non_fucose_num <- sum(gly_neighbors$mono != 'Fuc')
+  non_fucose_num <- sum(!is_fucose_like)
 
   if (neighbor_num == 2 && !has_fucose) {
     return(.spread_two_child_subtrees(coor, structure, ver))
@@ -786,15 +788,15 @@
   coor
 }
 
-#' Apply Fuc branch offsets and orientation to all vertices
+#' Apply Fuc-like branch offsets and orientation to all vertices
 #'
 #' @param structure An igraph glycan graph whose vertices include `mono` and
 #'   whose edges include `linkage`.
 #' @param coor A numeric coordinate matrix with columns `x` and `y`.
 #'
-#' @returns The same coordinate matrix shape as `coor`, with Fuc branches moved
-#'   to the linkage-specific side and any elongated Fuc descendants rotated with
-#'   the branch.
+#' @returns The same coordinate matrix shape as `coor`, with Fuc-like branches
+#'   moved to the linkage-specific side and any elongated descendants rotated
+#'   with the branch.
 #' @noRd
 .orient_fucose_branch_subtrees <- function(structure, coor) {
   for (ver in .reverse_vertex_order(structure)) {
@@ -803,20 +805,20 @@
   coor
 }
 
-#' Apply Fuc branch offsets and orientation for one parent vertex
+#' Apply Fuc-like branch offsets and orientation for one parent vertex
 #'
 #' @param structure An igraph glycan graph whose vertices include `mono` and
 #'   whose edges include `linkage`.
 #' @param coor A numeric coordinate matrix with columns `x` and `y`.
 #' @param ver A single integer parent vertex index.
 #'
-#' @returns The same coordinate matrix shape as `coor`. If `ver` has Fuc
-#'   children, each Fuc subtree is shifted and elongated descendants are
-#'   oriented with the branch; otherwise `coor` is returned unchanged.
+#' @returns The same coordinate matrix shape as `coor`. If `ver` has Fuc-like
+#'   children, each subtree is shifted and elongated descendants are oriented
+#'   with the branch; otherwise `coor` is returned unchanged.
 #' @noRd
 .orient_fucose_children_for_vertex <- function(structure, coor, ver) {
   neigh_pos <- igraph::neighbors(structure, ver)
-  fuc_pos <- neigh_pos[which(neigh_pos$mono == 'Fuc')]
+  fuc_pos <- neigh_pos[.is_fucose_like_layout_monosaccharide(neigh_pos$mono)]
   if (length(fuc_pos) == 0) {
     return(coor)
   }
@@ -882,12 +884,12 @@
 #' @param structure An igraph glycan graph whose vertices include `mono`.
 #' @param coor A numeric coordinate matrix with rendered columns `x` and `y`,
 #'   one row per graph vertex.
-#' @param fuc_orient Fuc triangle orientation, either `"flex"` or `"up"`.
+#' @param fuc_orient Fuc-like triangle orientation, either `"flex"` or `"up"`.
 #'
 #' @returns A character vector with one value per vertex. Most values are copied
-#'   from `mono`; in flexible Fuc orientation, non-reducing Fuc residues are
-#'   mapped to directional shape names so the triangle apex points toward the
-#'   rendered linkage direction.
+#'   from `mono`; in flexible Fuc-like orientation, non-reducing Fuc-like
+#'   orientable residues are mapped to directional shape names so the triangle
+#'   apex points toward the rendered linkage direction.
 #' @noRd
 .residue_glycoforms <- function(
   structure,
@@ -903,7 +905,7 @@
     coor <- .calculate_residue_coordinates(structure)
   }
 
-  for (i in c(which(glycoform == 'Fuc'))) {
+  for (i in which(.is_fucose_like_orient_monosaccharide(glycoform))) {
     if (!.is_reducing_end(structure, i)) {
       glycoform[i] <- .fucose_directional_glycoform(structure, coor, i)
     }
@@ -911,30 +913,32 @@
   return(glycoform)
 }
 
-#' Get directional Fuc shape name from rendered linkage direction
+#' Get directional Fuc-like shape name from rendered linkage direction
 #'
 #' @param structure An igraph glycan graph.
 #' @param coor A numeric coordinate matrix with rendered columns `x` and `y`.
-#' @param fuc_pos A single integer vertex index whose residue is Fuc.
+#' @param fuc_pos A single integer vertex index whose residue is Fuc-like.
 #'
-#' @returns A Fuc glycoform string: `"Fuc"` points up, `"FucUp"` points down,
-#'   `"FucRight"` points right, and `"FucLeft"` points left.
+#' @returns A glycoform string with no suffix for up-pointing shapes, an `"Up"`
+#'   suffix for down-pointing shapes, a `"Right"` suffix for right-pointing
+#'   shapes, and a `"Left"` suffix for left-pointing shapes.
 #' @noRd
 .fucose_directional_glycoform <- function(structure, coor, fuc_pos) {
+  mono <- igraph::V(structure)[[fuc_pos]]$mono
   parent_pos <- as.integer(igraph::neighbors(structure, fuc_pos, mode = "in"))
   if (length(parent_pos) == 0) {
-    return("Fuc")
+    return(mono)
   }
 
   linkage_vec <- coor[parent_pos[1], c("x", "y")] - coor[fuc_pos, c("x", "y")]
   if (abs(linkage_vec[["x"]]) > abs(linkage_vec[["y"]])) {
     if (linkage_vec[["x"]] > 0) {
-      return("FucRight")
+      return(paste0(mono, "Right"))
     }
-    return("FucLeft")
+    return(paste0(mono, "Left"))
   }
   if (linkage_vec[["y"]] < 0) {
-    return("FucUp")
+    return(paste0(mono, "Up"))
   }
-  "Fuc"
+  mono
 }

--- a/R/internal-data.R
+++ b/R/internal-data.R
@@ -66,6 +66,21 @@ glycan_dict <- list(
   'FucUp' = c('dHexUp', 'glyRed'),
   'FucRight' = c('dHexRight', 'glyRed'),
   'FucLeft' = c('dHexLeft', 'glyRed'),
+  'QuiUp' = c('dHexUp', 'glyBlue'),
+  'QuiRight' = c('dHexRight', 'glyBlue'),
+  'QuiLeft' = c('dHexLeft', 'glyBlue'),
+  'RhaUp' = c('dHexUp', 'glyGreen'),
+  'RhaRight' = c('dHexRight', 'glyGreen'),
+  'RhaLeft' = c('dHexLeft', 'glyGreen'),
+  '6dGulUp' = c('dHexUp', 'glyOrange'),
+  '6dGulRight' = c('dHexRight', 'glyOrange'),
+  '6dGulLeft' = c('dHexLeft', 'glyOrange'),
+  '6dAltUp' = c('dHexUp', 'glyPink'),
+  '6dAltRight' = c('dHexRight', 'glyPink'),
+  '6dAltLeft' = c('dHexLeft', 'glyPink'),
+  '6dTalUp' = c('dHexUp', 'glyLightBlue'),
+  '6dTalRight' = c('dHexRight', 'glyLightBlue'),
+  '6dTalLeft' = c('dHexLeft', 'glyLightBlue'),
 
   'dHexNAc' = c('dHexNAc', 'glyWhite', 'glyWhite'),
   'QuiNAc' = c('dHexNAc', 'glyBlue', 'glyWhite'),
@@ -73,6 +88,28 @@ glycan_dict <- list(
   '6dAltNAc' = c('dHexNAc', 'glyPink', 'glyWhite'),
   '6dTalNAc' = c('dHexNAc', 'glyLightBlue', 'glyWhite'),
   'FucNAc' = c('dHexNAc', 'glyRed', 'glyWhite'),
+  'QuiNAcUp' = c('dHexNAcUp', 'glyBlue', 'glyWhite'),
+  'QuiNAcRight' = c('dHexNAcRight', 'glyBlue', 'glyWhite'),
+  'QuiNAcLeft' = c('dHexNAcLeft', 'glyBlue', 'glyWhite'),
+  'RhaNAcUp' = c('dHexNAcUp', 'glyGreen', 'glyWhite'),
+  'RhaNAcRight' = c('dHexNAcRight', 'glyGreen', 'glyWhite'),
+  'RhaNAcLeft' = c('dHexNAcLeft', 'glyGreen', 'glyWhite'),
+  '6dAltNAcUp' = c('dHexNAcUp', 'glyPink', 'glyWhite'),
+  '6dAltNAcRight' = c('dHexNAcRight', 'glyPink', 'glyWhite'),
+  '6dAltNAcLeft' = c('dHexNAcLeft', 'glyPink', 'glyWhite'),
+  '6dTalNAcUp' = c('dHexNAcUp', 'glyLightBlue', 'glyWhite'),
+  '6dTalNAcRight' = c('dHexNAcRight', 'glyLightBlue', 'glyWhite'),
+  '6dTalNAcLeft' = c('dHexNAcLeft', 'glyLightBlue', 'glyWhite'),
+  'FucNAcUp' = c('dHexNAcUp', 'glyRed', 'glyWhite'),
+  'FucNAcRight' = c('dHexNAcRight', 'glyRed', 'glyWhite'),
+  'FucNAcLeft' = c('dHexNAcLeft', 'glyRed', 'glyWhite'),
+
+  'Oli' = c('ddHex', 'glyBlue'),
+  'Tyv' = c('ddHex', 'glyGreen'),
+  'Abe' = c('ddHex', 'glyOrange'),
+  'Par' = c('ddHex', 'glyPink'),
+  'Dig' = c('ddHex', 'glyPurple'),
+  'Col' = c('ddHex', 'glyLightBlue'),
 
   'Pen' = c('Pen', 'glyWhite'),
   'Ara' = c('Pen', 'glyGreen'),
@@ -153,6 +190,24 @@ glycan_shape <- list(
     xx = c(0, -1, 0, 0),
     yy = c(0.67 * sqrt(3), -0.33 * sqrt(3), -0.33 * sqrt(3), 0.67 * sqrt(3))
   ),
+  'dHexNAcUp' = data.frame(
+    x = c(0, 1, 0, 0),
+    y = c(-0.67 * sqrt(3), 0.33 * sqrt(3), 0.33 * sqrt(3), -0.67 * sqrt(3)),
+    xx = c(0, -1, 0, 0),
+    yy = c(-0.67 * sqrt(3), 0.33 * sqrt(3), 0.33 * sqrt(3), -0.67 * sqrt(3))
+  ),
+  'dHexNAcRight' = data.frame(
+    x = c(0.67 * sqrt(3), -0.33 * sqrt(3), -0.33 * sqrt(3), 0.67 * sqrt(3)),
+    y = c(0, 1, 0, 0),
+    xx = c(0.67 * sqrt(3), -0.33 * sqrt(3), -0.33 * sqrt(3), 0.67 * sqrt(3)),
+    yy = c(0, -1, 0, 0)
+  ),
+  'dHexNAcLeft' = data.frame(
+    x = c(-0.67 * sqrt(3), 0.33 * sqrt(3), 0.33 * sqrt(3), -0.67 * sqrt(3)),
+    y = c(0, 1, 0, 0),
+    xx = c(-0.67 * sqrt(3), 0.33 * sqrt(3), 0.33 * sqrt(3), -0.67 * sqrt(3)),
+    yy = c(0, -1, 0, 0)
+  ),
   'ddHex' = data.frame(x = c(-1, 1, 1, -1), y = c(0.5, 0.5, -0.5, -0.5)),
   'Pen' = data.frame(
     x = c(
@@ -193,3 +248,76 @@ glycan_shape <- list(
     y = c(0.905, 0.2132, -0.905, -0.905, 0.2132, 0.905)
   )
 )
+
+.fucose_like_layout_monosaccharides <- c(
+  "Fuc",
+  "Qui",
+  "Rha",
+  "6dGul",
+  "6dAlt",
+  "6dTal",
+  "QuiNAc",
+  "RhaNAc",
+  "6dAltNAc",
+  "6dTalNAc",
+  "FucNAc",
+  "Oli",
+  "Tyv",
+  "Abe",
+  "Par",
+  "Dig",
+  "Col",
+  "Ara",
+  "Lyx",
+  "Xyl",
+  "Rib"
+)
+
+.fucose_like_orient_monosaccharides <- c(
+  "Fuc",
+  "Qui",
+  "Rha",
+  "6dGul",
+  "6dAlt",
+  "6dTal",
+  "QuiNAc",
+  "RhaNAc",
+  "6dAltNAc",
+  "6dTalNAc",
+  "FucNAc"
+)
+
+#' Identify residues that use Fuc-like branch layout
+#'
+#' @param mono A character vector of monosaccharide names.
+#'
+#' @returns A logical vector indicating whether each monosaccharide should use
+#'   linkage-specific Fuc-like branch offsets.
+#' @noRd
+.is_fucose_like_layout_monosaccharide <- function(mono) {
+  mono %in% .fucose_like_layout_monosaccharides
+}
+
+#' Identify residues that use Fuc-like directional shapes
+#'
+#' @param mono A character vector of monosaccharide names.
+#'
+#' @returns A logical vector indicating whether each monosaccharide should use
+#'   directional glycoform names when `fuc_orient = "flex"`.
+#' @noRd
+.is_fucose_like_orient_monosaccharide <- function(mono) {
+  mono %in% .fucose_like_orient_monosaccharides
+}
+
+#' Get internal directional Fuc-like glycoform names
+#'
+#' @returns A character vector of glycoform names used only for directional
+#'   rendering of Fuc-like residues.
+#' @noRd
+.directional_fucose_like_glycoforms <- function() {
+  as.vector(outer(
+    .fucose_like_orient_monosaccharides,
+    c("Up", "Right", "Left"),
+    paste0
+  ))
+}

--- a/man/draw_cartoon.Rd
+++ b/man/draw_cartoon.Rd
@@ -30,10 +30,10 @@ TRUE. Substituent annotations are always shown.}
 \item{orient}{The orientation of glycan structure. "H" for horizontal, "V" for vertical.
 Default is "H"}
 
-\item{fuc_orient}{Fuc triangle orientation. \code{"flex"} points non-reducing Fuc
-residues toward their rendered linkage direction, while \code{"up"} draws all
-Fuc triangles pointing upward. Reducing-end Fuc residues always point
-upward. Defaults to \code{"flex"}.}
+\item{fuc_orient}{Fuc-like triangle orientation. \code{"flex"} points
+non-reducing Fuc-like residues toward their rendered linkage direction,
+while \code{"up"} draws all Fuc-like triangles pointing upward. Reducing-end
+Fuc-like residues always point upward. Defaults to \code{"flex"}.}
 
 \item{red_end}{Reducing-end annotation. The default \code{""} keeps the current
 reducing-end line. Use \code{"~"} to add a wavy reducing end, or any other

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -43,10 +43,10 @@ TRUE. Substituent annotations are always shown.}
 \item{orient}{The orientation of glycan structure. "H" for horizontal, "V" for vertical.
 Default is "H"}
 
-\item{fuc_orient}{Fuc triangle orientation. \code{"flex"} points non-reducing Fuc
-residues toward their rendered linkage direction, while \code{"up"} draws all
-Fuc triangles pointing upward. Reducing-end Fuc residues always point
-upward. Defaults to \code{"flex"}.}
+\item{fuc_orient}{Fuc-like triangle orientation. \code{"flex"} points
+non-reducing Fuc-like residues toward their rendered linkage direction,
+while \code{"up"} draws all Fuc-like triangles pointing upward. Reducing-end
+Fuc-like residues always point upward. Defaults to \code{"flex"}.}
 
 \item{red_end}{Reducing-end annotation. The default \code{""} keeps the current
 reducing-end line. Use \code{"~"} to add a wavy reducing end, or any other

--- a/tests/testthat/test-glydraw.R
+++ b/tests/testthat/test-glydraw.R
@@ -24,6 +24,51 @@ has_triangle_apex <- function(polygon, center, direction) {
   )
 }
 
+fuc_like_branch_graph <- function(monos, linkages = c("a1-3", "a1-6")) {
+  parent <- length(monos) + 1
+  graph <- igraph::make_empty_graph(parent, directed = TRUE)
+  graph <- igraph::add_edges(graph, as.vector(rbind(parent, seq_along(monos))))
+  igraph::V(graph)$mono <- c(monos, "GlcNAc")
+  igraph::E(graph)$linkage <- linkages
+  graph
+}
+
+fuc_like_layout_monos <- c(
+  "Qui",
+  "Rha",
+  "6dGul",
+  "6dAlt",
+  "6dTal",
+  "QuiNAc",
+  "RhaNAc",
+  "6dAltNAc",
+  "6dTalNAc",
+  "FucNAc",
+  "Oli",
+  "Tyv",
+  "Abe",
+  "Par",
+  "Dig",
+  "Col",
+  "Ara",
+  "Lyx",
+  "Xyl",
+  "Rib"
+)
+
+fuc_like_orient_monos <- c(
+  "Qui",
+  "Rha",
+  "6dGul",
+  "6dAlt",
+  "6dTal",
+  "QuiNAc",
+  "RhaNAc",
+  "6dAltNAc",
+  "6dTalNAc",
+  "FucNAc"
+)
+
 test_that("draw_cartoon works with valid branched glycan structure", {
   structure <- "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
 
@@ -531,6 +576,19 @@ test_that("draw_cartoon places a1-6 core Fuc up and a1-3 core Fuc down", {
   expect_lt(min(fuc_segments$yend), -0.5)
 })
 
+test_that("Fuc-like residues use linkage-specific branch sides", {
+  purrr::walk(fuc_like_layout_monos, function(mono) {
+    graph <- fuc_like_branch_graph(c(mono, mono))
+    coor <- .calculate_residue_coordinates(graph)
+
+    expect_equal(
+      unname(coor[1:2, "y"]),
+      c(-1, 1),
+      info = mono
+    )
+  })
+})
+
 test_that("draw_cartoon handles two Fuc branches plus one non-Fuc branch", {
   structure <- .as_single_glycan_structure(
     "Fuc(a1-3)[Fuc(a1-6)][GlcNAc(b1-4)]GlcNAc(b1-"
@@ -589,6 +647,40 @@ test_that("draw_cartoon controls Fuc triangle orientation", {
   expect_true(has_triangle_apex(up_fuc[[2]], c(x = -1, y = 1), "up"))
 })
 
+test_that("Fuc-like residues inherit flexible triangle orientation", {
+  purrr::walk(fuc_like_orient_monos, function(mono) {
+    graph <- fuc_like_branch_graph(c(mono, mono))
+    horizontal_coor <- matrix(
+      c(-1, -1, -1, 1, -1, 0),
+      ncol = 2,
+      byrow = TRUE,
+      dimnames = list(NULL, c("x", "y"))
+    )
+    vertical_coor <- matrix(
+      c(-1, 1, 1, 1, 0, 1),
+      ncol = 2,
+      byrow = TRUE,
+      dimnames = list(NULL, c("x", "y"))
+    )
+
+    expect_equal(
+      .residue_glycoforms(graph, horizontal_coor, fuc_orient = "flex"),
+      c(mono, paste0(mono, "Up"), "GlcNAc"),
+      info = mono
+    )
+    expect_equal(
+      .residue_glycoforms(graph, vertical_coor, fuc_orient = "flex"),
+      c(paste0(mono, "Right"), paste0(mono, "Left"), "GlcNAc"),
+      info = mono
+    )
+    expect_equal(
+      .residue_glycoforms(graph, vertical_coor, fuc_orient = "up"),
+      c(mono, mono, "GlcNAc"),
+      info = mono
+    )
+  })
+})
+
 test_that("draw_cartoon points vertical Fuc triangles toward their linkage", {
   structure <- "Fuc(a1-3)[Fuc(a1-6)]GlcNAc(b1-4)GlcNAc(b1-"
 
@@ -606,6 +698,17 @@ test_that("draw_cartoon keeps reducing-end Fuc triangles up", {
   fuc <- fuc_triangle_polygons(plot)
 
   expect_true(has_triangle_apex(fuc[[1]], c(x = 0, y = 0), "up"))
+})
+
+test_that("draw_cartoon renders Fuc-like ddHex branches", {
+  glycans <- paste0(
+    c("Oli", "Tyv", "Abe", "Par", "Dig", "Col"),
+    "(a1-3)GlcNAc(b1-"
+  )
+
+  cartoons <- purrr::map(glycans, draw_cartoon)
+
+  purrr::walk(cartoons, expect_s3_class, "glydraw_cartoon")
 })
 
 test_that(".calculate_residue_coordinates keeps same-column residues at least one unit apart", {


### PR DESCRIPTION
Summary

Extend Fuc-style branch-side layout and flexible triangle orientation to additional Fuc-like monosaccharides.

Details

- Treat requested dHex, dHexNAc, ddHex, and pentose residues as Fuc-like for linkage-specific branch-side layout.
- Add directional internal glycoform mappings for Fuc-like dHex and dHexNAc residues so `fuc_orient = "flex"` can point them toward their rendered linkage direction.
- Add ddHex dictionary mappings for `Oli`, `Tyv`, `Abe`, `Par`, `Dig`, and `Col` so parsed structures using those residues render.
- Update `fuc_orient` docs to describe the broadened Fuc-like behavior.
- Add regression coverage for the widened layout and orientation sets.
- Add a `NEWS.md` entry for the user-visible rendering update.

Verification

- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::test(filter = "glydraw")'` (219 passed)
- `Rscript -e 'devtools::test()'` (225 passed)
- `git diff --check`