### PR TITLE
Fix dHex Fuc-like cartoon layout

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@ This version of glydraw introduced some `ggplot2` extensions.
 * New `scale_x_glycan()` and `scale_y_glycan()` display glycan cartoons as discrete ggplot2 axis labels.
 * New `hjust_red_end()` and `vjust_red_end()` anchor vertical and horizontal cartoons at their reducing ends in `geom_glycan()`, `scale_x_glycan()`, `scale_y_glycan()`, and `guide_glycan()`. `guide_glycan()` also gains `hjust` and `vjust` parameters. Reducing-end justification is the default for scale and guide cartoons along the axis perpendicular to their drawing orientation; `geom_glycan()` remains centered by default. (#54)
 
+## Minor improvements and bug fixes
+
+* `draw_cartoon()` now treats generic `dHex` residues as Fuc-like branches, using the same layout and `fuc_orient` behavior as Fuc. (#56)
+
 # glydraw 0.6.3
 
 * First release on CRAN.

--- a/R/internal-data.R
+++ b/R/internal-data.R
@@ -57,6 +57,9 @@ glycan_dict <- list(
   'IdoA' = c('HexA', 'glyBrown', 'glyWhite'),
 
   'dHex' = c('dHex', 'glyWhite'),
+  'dHexUp' = c('dHexUp', 'glyWhite'),
+  'dHexRight' = c('dHexRight', 'glyWhite'),
+  'dHexLeft' = c('dHexLeft', 'glyWhite'),
   'Qui' = c('dHex', 'glyBlue'),
   'Rha' = c('dHex', 'glyGreen'),
   '6dGul' = c('dHex', 'glyOrange'),
@@ -250,6 +253,7 @@ glycan_shape <- list(
 )
 
 .fucose_like_layout_monosaccharides <- c(
+  "dHex",
   "Fuc",
   "Qui",
   "Rha",
@@ -274,6 +278,7 @@ glycan_shape <- list(
 )
 
 .fucose_like_orient_monosaccharides <- c(
+  "dHex",
   "Fuc",
   "Qui",
   "Rha",

--- a/tests/testthat/test-draw-cartoon.R
+++ b/tests/testthat/test-draw-cartoon.R
@@ -170,6 +170,23 @@ test_that("left and right Fuc-like triangles align with rectangle borders", {
   })
 })
 
+test_that("dHex uses Fuc-like layout and orientation", {
+  structure <- "HexNAc(??-?)[dHex(??-?)]HexNAc(??-"
+  inputs <- .prepare_cartoon_inputs(structure, NULL, "H", "")
+  dhex <- which(igraph::V(inputs$structure)$mono == "dHex")
+
+  expect_equal(inputs$coor[dhex, ], c(x = 0, y = 1))
+  expect_equal(
+    .residue_glycoforms(inputs$structure, inputs$coor, "flex")[dhex],
+    "dHexUp"
+  )
+  expect_equal(
+    .residue_glycoforms(inputs$structure, inputs$coor, "up")[dhex],
+    "dHex"
+  )
+  expect_s3_class(draw_cartoon(structure), "glydraw_cartoon")
+})
+
 test_that("draw_cartoon left-aligns vertical substituent labels", {
   structure <- "Neu5Ac9Ac(a2-3)Gal6S(b1-"
 


### PR DESCRIPTION
## Summary

- Treat `dHex` as a Fuc-like residue for branch placement and flexible triangle orientation.
- Add the missing directional `dHex` glyph mappings.
- Add a regression for `HexNAc(??-?)[dHex(??-?)]HexNAc(??-`.

## Verification

- `devtools::test()`
- `devtools::check(document = FALSE, manual = FALSE, error_on = "error")`
- `draw_cartoon("HexNAc(??-?)[dHex(??-?)]HexNAc(??-")` renders the dHex branch using the Fuc-like rule.

## NEWS

- Added the development NEWS entry with the live PR reference: `(#56)`.