### PR TITLE
Fix bisecting GlcNAc layout without linkage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@ This version of glydraw introduced some `ggplot2` extensions.
 
 ## Minor improvements and bug fixes
 
-* Recognize bisecting GlcNAc from N-glycan topology when linkage information is unavailable, keeping it centered between the two mannose arms. (#57)
+* Recognize bisecting GlcNAc from N-glycan topology when linkage information is unavailable, keeping it centered between the two mannose arms. (#58)
 * `draw_cartoon()` now treats generic `dHex` residues as Fuc-like branches, using the same layout and `fuc_orient` behavior as Fuc. (#56)
 
 # glydraw 0.6.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ This version of glydraw introduced some `ggplot2` extensions.
 
 ## Minor improvements and bug fixes
 
+* Recognize bisecting GlcNAc from N-glycan topology when linkage information is unavailable, keeping it centered between the two mannose arms. (#57)
 * `draw_cartoon()` now treats generic `dHex` residues as Fuc-like branches, using the same layout and `fuc_orient` behavior as Fuc. (#56)
 
 # glydraw 0.6.3

--- a/R/internal-coordinates.R
+++ b/R/internal-coordinates.R
@@ -177,8 +177,10 @@
 #' @param ver A single integer vertex index.
 #'
 #' @returns An igraph vertex sequence of neighbors for `ver`, excluding
-#'   Fuc-like neighbors. Numeric linkage positions are sorted decreasing;
-#'   unknown or compound linkage values are placed at the bottom.
+#'   Fuc-like neighbors. A GlcNAc flanked by two Man children is kept in the
+#'   middle so bisecting GlcNAc is recognized from topology. Otherwise, numeric
+#'   linkage positions are sorted decreasing; unknown or compound linkage
+#'   values are placed at the bottom.
 #'
 #' @noRd
 .order_child_vertices_by_linkage <- function(structure, ver) {
@@ -193,10 +195,29 @@
   if (!all(is.na(neigh_linkage))) {
     neigh_linkage[is.na(neigh_linkage)] <- -Inf # Set '?' or '3/6' type as bottom
     arrange_neigh_pos <- neigh_pos[order(neigh_linkage, decreasing = TRUE)]
-    return(arrange_neigh_pos)
   } else {
-    return(neigh_pos) # No sorting if all linkages are '?' or '3/6' type
+    arrange_neigh_pos <- neigh_pos # No sorting if all linkages are '?' or '3/6' type
   }
+
+  .center_bisecting_glcnac(arrange_neigh_pos)
+}
+
+#' Center a topologically identified bisecting GlcNAc
+#'
+#' @param child_pos An igraph vertex sequence of non-Fuc-like child residues in
+#'   their preferred branch order.
+#'
+#' @returns `child_pos`, with GlcNAc placed between two Man children when those
+#'   are the only three child residues.
+#' @noRd
+.center_bisecting_glcnac <- function(child_pos) {
+  is_man <- child_pos$mono == "Man"
+  is_glcnac <- child_pos$mono == "GlcNAc"
+  if (sum(is_man) != 2 || sum(is_glcnac) != 1 || length(child_pos) != 3) {
+    return(child_pos)
+  }
+
+  child_pos[c(which(is_man)[1], which(is_glcnac), which(is_man)[2])]
 }
 
 #' Spread two child subtrees around their parent

--- a/tests/testthat/test-draw-cartoon.R
+++ b/tests/testthat/test-draw-cartoon.R
@@ -187,6 +187,31 @@ test_that("dHex uses Fuc-like layout and orientation", {
   expect_s3_class(draw_cartoon(structure), "glydraw_cartoon")
 })
 
+test_that("bisecting GlcNAc is centered without linkage information", {
+  structure <- paste0(
+    "Neu5Ac(??-?)Gal(??-?)GlcNAc(??-?)Man(??-?)",
+    "[Gal(??-?)GlcNAc(??-?)Man(??-?)]",
+    "[GlcNAc(??-?)]Man(??-?)GlcNAc(??-?)GlcNAc(??-"
+  )
+  inputs <- .prepare_cartoon_inputs(structure, NULL, "H", "")
+  graph <- inputs$structure
+  child_num <- purrr::map_int(
+    seq_along(igraph::V(graph)),
+    \(vertex) length(igraph::neighbors(graph, vertex, mode = "out"))
+  )
+  core <- which(igraph::V(graph)$mono == "Man" & child_num == 3)
+  children <- as.integer(igraph::neighbors(graph, core, mode = "out"))
+  bisecting <- children[igraph::V(graph)[children]$mono == "GlcNAc"]
+  arms <- children[igraph::V(graph)[children]$mono == "Man"]
+
+  expect_equal(unname(inputs$coor[bisecting, "y"]), 0)
+  expect_equal(sort(unname(inputs$coor[arms, "y"])), c(-1, 1))
+  expect_s3_class(
+    draw_cartoon(structure, show_linkage = FALSE),
+    "glydraw_cartoon"
+  )
+})
+
 test_that("draw_cartoon left-aligns vertical substituent labels", {
   structure <- "Neu5Ac9Ac(a2-3)Gal6S(b1-"
 


### PR DESCRIPTION
Closes #57

## Summary

Recognize a bisecting GlcNAc from the N-glycan topology when linkage positions are unavailable.

Keep the GlcNAc centered when a core Man has exactly two Man children and one GlcNAc child, while preserving linkage-based ordering for other branches.

Add regression coverage using the structure reported in issue #57 and document the fix in NEWS with the live PR reference.

## Verification

- `Rscript -e 'devtools::test()'` (324 expectations passed)
- `Rscript -e 'devtools::check(error_on = "warning")'` (0 errors, 0 warnings, 1 local clock-verification note)
- Visually verified that the bisecting GlcNAc remains centered between the two mannose arms when all linkages are `??-?`