### PR TITLE
Improve glycan annotation and geom rendering performance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     rlang,
     dplyr,
     ggplot2 (>= 4.0.0),
-    igraph,
+    igraph (>= 2.2.0),
     purrr,
     png,
     glyparse,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # glydraw (development version)
 
+* `draw_cartoon()` and `geom_glycan()` now prepare linkage annotations and repeated panel structures more efficiently, improving rendering performance while preserving cartoon layout and appearance. (#64)
+
 # glydraw 0.7.0
 
 This version of glydraw introduced some `ggplot2` extensions.

--- a/R/geom-glycan.R
+++ b/R/geom-glycan.R
@@ -270,9 +270,36 @@ geom_glycan <- function(
   .validate_glycan_justification(coordinates$hjust, "hjust")
   .validate_glycan_justification(coordinates$vjust, "vjust")
   .validate_glycan_angles(coordinates$angle)
+  structure_input <- coordinates$structure
+  if (
+    !is.null(highlight) &&
+      !glyrepr::is_glycan_structure(structure_input)
+  ) {
+    cli::cli_warn(
+      "{.arg highlight} can only be set when {.arg structure} is a {.fn glyrepr::glycan_structure}."
+    )
+    highlight <- NULL
+  }
+  structures <- .as_glycan_structure_input(structure_input)
+  unique_structures <- unique(structures)
+  structure_index <- match(structures, unique_structures)
+  grob_cache <- lapply(seq_along(unique_structures), function(index) {
+    glycanGrob(
+      unique_structures[[index]],
+      show_linkage = show_linkage,
+      orient = orient,
+      fuc_orient = fuc_orient,
+      red_end = red_end,
+      edge_linewidth = edge_linewidth,
+      node_linewidth = node_linewidth,
+      node_size = node_size,
+      colors = colours,
+      highlight = highlight
+    )
+  })
   grobs <- purrr::pmap(
     list(
-      structure = coordinates$structure,
+      grob = grob_cache[structure_index],
       x = coordinates$x,
       y = coordinates$y,
       size = coordinates$size,
@@ -281,20 +308,8 @@ geom_glycan <- function(
       angle = coordinates$angle,
       index = seq_len(nrow(coordinates))
     ),
-    function(structure, x, y, size, hjust, vjust, angle, index) {
-      glycanGrob(
-        structure,
-        show_linkage = show_linkage,
-        orient = orient,
-        fuc_orient = fuc_orient,
-        red_end = red_end,
-        edge_linewidth = edge_linewidth,
-        node_linewidth = node_linewidth,
-        node_size = node_size,
-        colors = colours,
-        highlight = highlight
-      ) |>
-        .position_glycan_grob(x, y, size, hjust, vjust, angle, index)
+    function(grob, x, y, size, hjust, vjust, angle, index) {
+      .position_glycan_grob(grob, x, y, size, hjust, vjust, angle, index)
     }
   )
 

--- a/R/glycan-grob.R
+++ b/R/glycan-grob.R
@@ -81,7 +81,8 @@ glycanGrob <- function(
     orient,
     style$red_end,
     highlight,
-    node_size = style$node_size
+    node_size = style$node_size,
+    show_linkage = show_linkage
   )
   connect_df <- .cartoon_segment_data(
     structure,

--- a/R/internal-annotations.R
+++ b/R/internal-annotations.R
@@ -225,18 +225,60 @@
   }
   orient <- rlang::arg_match(orient)
 
-  annotation <- purrr::map_dfr(
-    seq_len(length(structure) - 1),
-    \(ver) {
-      .linkage_annotation_rows(
-        structure,
-        coor,
-        ver,
-        node_size = node_size,
-        orient = orient
-      )
-    }
+  child_vertices <- seq_len(length(structure) - 1)
+  parent_vertices <- .parent_vertices_for_annotations(structure)
+  linkage_labels <- strsplit(
+    igraph::E(structure)$linkage[child_vertices],
+    "-",
+    fixed = TRUE
   )
+  row_count <- 2L * length(child_vertices)
+  annotation <- data.frame(
+    vertice = rep(as.character(child_vertices), each = 2L),
+    annot = character(row_count),
+    x = numeric(row_count),
+    y = numeric(row_count),
+    segment_start_x = numeric(row_count),
+    segment_start_y = numeric(row_count),
+    segment_end_x = numeric(row_count),
+    segment_end_y = numeric(row_count),
+    stringsAsFactors = FALSE
+  )
+
+  for (ver in child_vertices) {
+    par_ver <- parent_vertices[[ver]]
+    offsets <- .linkage_label_offsets(
+      structure,
+      coor,
+      child_ver = ver,
+      parent_ver = par_ver,
+      orient = orient
+    )
+    label_positions <- .linkage_label_positions(
+      coor[ver, "x"],
+      coor[ver, "y"],
+      coor[par_ver, "x"],
+      coor[par_ver, "y"],
+      chil_offset = offsets[["child"]],
+      par_offset = offsets[["parent"]],
+      node_size = node_size
+    )
+    rows <- 2L * ver - c(1L, 0L)
+    annotation$annot[rows] <- linkage_labels[[ver]][1:2]
+    annotation$x[rows] <- c(
+      label_positions$chil[[1]] + coor[ver, "x"],
+      label_positions$par[[1]] + coor[par_ver, "x"]
+    )
+    annotation$y[rows] <- c(
+      label_positions$chil[[2]] + coor[ver, "y"],
+      label_positions$par[[2]] + coor[par_ver, "y"]
+    )
+    annotation$segment_start_x[rows] <- coor[ver, "x"]
+    annotation$segment_start_y[rows] <- coor[ver, "y"]
+    annotation$segment_end_x[rows] <- coor[par_ver, "x"]
+    annotation$segment_end_y[rows] <- coor[par_ver, "y"]
+  }
+
   annotation$annot <- .normalize_linkage_labels(annotation$annot)
   annotation
 }
@@ -337,6 +379,24 @@
     )$vpath[[1]]),
     -2
   )
+}
+
+#' Find parent vertices used for all linkage annotations
+#'
+#' @param structure An igraph glycan graph.
+#'
+#' @returns An integer vector with one parent vertex for each non-reducing
+#'   vertex, ordered by child vertex index.
+#' @noRd
+.parent_vertices_for_annotations <- function(structure) {
+  traversal <- igraph::bfs(
+    structure,
+    root = length(structure),
+    mode = "all",
+    unreachable = FALSE,
+    parent = TRUE
+  )
+  as.integer(traversal$parent[seq_len(length(structure) - 1)])
 }
 
 #' Calculate child-side and parent-side linkage label offsets

--- a/R/internal-cartoon.R
+++ b/R/internal-cartoon.R
@@ -275,6 +275,8 @@
 #'   highlight.
 #' @param node_size Numeric scalar used as a multiplier for the default node
 #'   size.
+#' @param show_linkage Logical scalar indicating whether linkage annotations
+#'   will be drawn.
 #'
 #' @returns A list with `annotation`, the complete text annotation data frame;
 #'   `show_without_linkage`, substituent and custom reducing-end text rows that
@@ -288,16 +290,10 @@
   orient = c("H", "V"),
   red_end = "",
   highlight = NULL,
-  node_size = 1
+  node_size = 1,
+  show_linkage = TRUE
 ) {
   orient <- rlang::arg_match(orient)
-  linkage_annotation <- .linkage_annotation_data(
-    structure,
-    coor,
-    node_size = node_size,
-    orient = orient
-  ) |>
-    dplyr::mutate(show_without_linkage = FALSE)
   substituent_annotation <- .substituent_annotation_data(
     structure,
     coor,
@@ -310,10 +306,6 @@
   )
   substituent_annotation <- substituent_annotation |>
     dplyr::mutate(show_without_linkage = TRUE)
-  struc_annotation <- dplyr::bind_rows(
-    linkage_annotation,
-    substituent_annotation
-  )
   reducing_info <- .reducing_end_annotation_data(
     structure,
     coor,
@@ -322,6 +314,24 @@
   )
   reducing_annotation <- reducing_info$annotation |>
     dplyr::mutate(show_without_linkage = .data$is_red_end_text)
+  visible_without_linkage <- nrow(substituent_annotation) > 0 ||
+    any(reducing_annotation$show_without_linkage)
+  if (show_linkage || visible_without_linkage) {
+    linkage_annotation <- .linkage_annotation_data(
+      structure,
+      coor,
+      node_size = node_size,
+      orient = orient
+    ) |>
+      dplyr::mutate(show_without_linkage = FALSE)
+  } else {
+    linkage_annotation <- .empty_linkage_annotation_data() |>
+      dplyr::mutate(show_without_linkage = logical())
+  }
+  struc_annotation <- dplyr::bind_rows(
+    linkage_annotation,
+    substituent_annotation
+  )
   struc_annotation <- dplyr::bind_rows(
     struc_annotation,
     reducing_annotation

--- a/tests/testthat/test-draw-cartoon.R
+++ b/tests/testthat/test-draw-cartoon.R
@@ -303,3 +303,35 @@ test_that("draw_cartoon preserves nested Xyl-Gal-Fuc side-chain order", {
     gal_labels$y > coor[xyl, "y"] & gal_labels$y < coor[gal, "y"]
   ))
 })
+
+test_that("linkage annotations preserve row-wise topology calculations", {
+  structures <- c(
+    "Gal(b1-3)[GlcNAc(b1-6)]GalNAc(a1-",
+    paste0(
+      "Neu5Ac(a2-3)Gal(b1-3)[Fuc(a1-2)Gal(b1-3)[Fuc(a1-4)]",
+      "GlcNAc(b1-3)[Gal(b1-4)GlcNAc(b1-6)]Gal(b1-4)",
+      "GlcNAc(b1-6)]GalNAc(a1-"
+    )
+  )
+
+  purrr::walk(structures, function(structure) {
+    inputs <- .prepare_cartoon_inputs(structure, NULL, "H", "")
+    expected <- purrr::map_dfr(
+      seq_len(length(inputs$structure) - 1),
+      \(.vertex) {
+        .linkage_annotation_rows(
+          inputs$structure,
+          inputs$coor,
+          .vertex,
+          orient = "H"
+        )
+      }
+    )
+    expected$annot <- .normalize_linkage_labels(expected$annot)
+
+    expect_identical(
+      .linkage_annotation_data(inputs$structure, inputs$coor, orient = "H"),
+      expected
+    )
+  })
+})

--- a/tests/testthat/test-draw-cartoon.R
+++ b/tests/testthat/test-draw-cartoon.R
@@ -257,6 +257,28 @@ test_that("draw_cartoon works with linkage hidden", {
   expect_s3_class(plot_no_linkage, "glydraw_cartoon")
 })
 
+test_that("linkage-hidden cartoons skip unused annotation construction", {
+  inputs <- .prepare_cartoon_inputs(
+    "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-",
+    NULL,
+    "H",
+    ""
+  )
+  testthat::local_mocked_bindings(
+    .linkage_annotation_data = function(...) {
+      stop("linkage annotations were constructed")
+    }
+  )
+
+  annotation <- .cartoon_text_annotation_data(
+    inputs$structure,
+    inputs$coor,
+    show_linkage = FALSE
+  )
+
+  expect_equal(nrow(annotation$show_without_linkage), 0)
+})
+
 test_that("draw_cartoon works with reducing-end O-Fuc glycans", {
   glycans <- c(
     "Fuc(a1-",

--- a/tests/testthat/test-geom-glycan.R
+++ b/tests/testthat/test-geom-glycan.R
@@ -100,6 +100,42 @@ test_that("geom_glycan draws one configured glycan grob per row", {
   expect_no_error(ggplot2::ggplotGrob(plot))
 })
 
+test_that("geom_glycan prepares repeated structures once per panel", {
+  structures <- c(
+    "Gal(b1-3)GalNAc(a1-",
+    "Gal(b1-3)GalNAc(a1-",
+    "Gal(b1-4)GlcNAc(b1-",
+    "Gal(b1-3)GalNAc(a1-"
+  )
+  data <- data.frame(
+    x = seq_along(structures),
+    y = 1,
+    structure = structures
+  )
+  call_count <- 0L
+  original_glycan_grob <- glycanGrob
+  testthat::local_mocked_bindings(
+    glycanGrob = function(...) {
+      call_count <<- call_count + 1L
+      original_glycan_grob(...)
+    }
+  )
+
+  plot <- ggplot2::ggplot(
+    data,
+    ggplot2::aes(
+      x = .data$x,
+      y = .data$y,
+      structure = .data$structure
+    )
+  ) +
+    geom_glycan()
+  layer <- ggplot2::layer_grob(plot)
+
+  expect_equal(call_count, 2L)
+  expect_length(layer[[1]]$children, length(structures))
+})
+
 test_that("geom_glycan requires structure, x, and y aesthetics", {
   data <- data.frame(x = 1, y = 1)
   plot <- ggplot2::ggplot(


### PR DESCRIPTION
## Summary

- Build linkage annotations in one preallocated data frame and derive parent vertices with one rooted traversal.
- Require igraph 2.2.0, the first release supporting the `bfs(parent = TRUE)` API used by the optimized traversal.
- Skip hidden linkage annotation work when no visible annotation depends on collision handling.
- Batch-parse panel structures and prepare each unique glycan once for repeated `geom_glycan()` rows.
- Preserve annotation, layout, sizing, highlighting, and positioned-grob behavior with targeted parity tests.
- Document the rendering performance improvements in the development NEWS entry.

## Performance

- Linkage annotation workload: 2.042 s to 1.270 s (1.61x).
- Linkage-hidden grob preparation: 1.278 s to 0.910 s (1.40x).
- Repeated 24-row `geom_glycan()` panel: 0.940 s to 0.269 s (3.49x).

## Verification

- `devtools::test()` passes 343 expectations.
- `devtools::check(error_on = "warning")` completes with 0 errors and 0 warnings; the only NOTE is local clock verification.
- Annotation outputs, linkage-hidden layer data, fixed sizing metadata, and positioned grob fields match the preceding implementations exactly.
