### PR TITLE
Support NULL reducing ends

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 ## Minor improvements and bug fixes
 
+* `red_end = NULL` now omits both the reducing-end line and its anomer annotation across glycan drawing interfaces.
+
 * Move beta linkage annotations slightly away from horizontal and skewed edge lines while leaving labels beside vertical edges unchanged, including reducing-end annotations. (#70)
 
 # glydraw 0.7.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 
 ## Minor improvements and bug fixes
 
-* `red_end = NULL` now omits both the reducing-end line and its anomer annotation across glycan drawing interfaces.
+* `red_end = NULL` now omits both the reducing-end line and its anomer annotation across glycan drawing interfaces. (#71)
 
 * Move beta linkage annotations slightly away from horizontal and skewed edge lines while leaving labels beside vertical edges unchanged, including reducing-end annotations. (#70)
 

--- a/R/anno-glycan.R
+++ b/R/anno-glycan.R
@@ -41,7 +41,8 @@
 #' @param show_linkage Whether to show glycosidic linkage annotations inside
 #'   the cartoons. Defaults to `TRUE`.
 #' @param red_end Reducing-end annotation passed to [glycanGrob()]. Use `"~"`
-#'   for a wave, or another string to display that text. Defaults to `""`.
+#'   for a wave, another string to display that text, or `NULL` to omit the
+#'   reducing-end line and anomer annotation. Defaults to `""`.
 #' @param fuc_orient Fuc-like triangle orientation passed to [glycanGrob()].
 #' @param edge_linewidth Linkage linewidth passed to [glycanGrob()].
 #' @param node_linewidth Node-border linewidth passed to [glycanGrob()].

--- a/R/draw-cartoon.R
+++ b/R/draw-cartoon.R
@@ -13,7 +13,8 @@
 #'   Fuc-like residues always point upward. Defaults to `"flex"`.
 #' @param red_end Reducing-end annotation. The default `""` keeps the current
 #'   reducing-end line. Use `"~"` to add a wavy reducing end, or any other
-#'   string to draw that string at the reducing end.
+#'   string to draw that string at the reducing end. Use `NULL` to omit the
+#'   reducing-end line and anomer annotation.
 #' @param edge_linewidth Numeric scalar controlling the linewidth of linkage
 #'   lines. Defaults to the current value, `0.8`.
 #' @param node_linewidth Numeric scalar controlling the linewidth of node

--- a/R/glydraw-style.R
+++ b/R/glydraw-style.R
@@ -9,7 +9,8 @@
 #' @param orient Direction in which the glycan extends from its reducing end:
 #'   one of `"left"`, `"right"`, `"up"`, or `"down"`. Defaults to `"left"`.
 #' @param fuc_orient Fuc-like triangle orientation: `"flex"` or `"up"`.
-#' @param red_end Reducing-end annotation. Use `"~"` for a wave.
+#' @param red_end Reducing-end annotation. Use `"~"` for a wave or `NULL` to
+#'   omit the reducing-end line and anomer annotation.
 #' @param edge_linewidth Linewidth of glycosidic linkages.
 #' @param node_linewidth Linewidth of node borders.
 #' @param node_size Multiplier for the default node size.
@@ -41,7 +42,7 @@ glydraw_style <- function(
   checkmate::assert_flag(show_linkage)
   orient <- rlang::arg_match(orient)
   fuc_orient <- rlang::arg_match(fuc_orient)
-  checkmate::assert_string(red_end, na.ok = FALSE)
+  checkmate::assert_string(red_end, na.ok = FALSE, null.ok = TRUE)
   checkmate::assert_number(edge_linewidth, lower = 0)
   checkmate::assert_number(node_linewidth, lower = 0)
   .validate_node_size(node_size)

--- a/R/guide-glycan.R
+++ b/R/guide-glycan.R
@@ -22,7 +22,8 @@
 #' @param show_linkage Whether to show glycosidic linkage annotations inside
 #'   the cartoons. Defaults to `TRUE`.
 #' @param red_end Reducing-end annotation passed to [glycanGrob()]. Use `"~"`
-#'   for a wave, or another string to display that text. Defaults to `""`.
+#'   for a wave, another string to display that text, or `NULL` to omit the
+#'   reducing-end line and anomer annotation. Defaults to `""`.
 #' @param fuc_orient Fuc-like triangle orientation passed to [glycanGrob()].
 #' @param edge_linewidth Linkage linewidth passed to [glycanGrob()].
 #' @param node_linewidth Node-border linewidth passed to [glycanGrob()].

--- a/R/internal-annotations.R
+++ b/R/internal-annotations.R
@@ -1124,8 +1124,9 @@
 #'   per graph vertex.
 #' @param orient Drawing orientation, one of `"left"`, `"right"`, `"up"`, or
 #'   `"down"`.
-#' @param red_end A string. `""` draws only the current reducing-end line,
-#'   `"~"` draws a wavy end, and any other string draws custom text.
+#' @param red_end A string or `NULL`. `NULL` omits the reducing end, `""`
+#'   draws only the current reducing-end line, `"~"` draws a wavy end, and any
+#'   other string draws custom text.
 #'
 #' @returns A list with data frames `annotation`, `segment`, `wave`, and
 #'   `bounds`. `annotation` contains text rows; `segment` contains one line
@@ -1139,6 +1140,9 @@
   red_end = ""
 ) {
   orient <- rlang::arg_match(orient)
+  if (is.null(red_end)) {
+    return(.empty_reducing_end_annotation_data())
+  }
   anomer <- igraph::graph_attr(structure, "anomer")
   if (.has_no_reducing_end_anomer(anomer)) {
     return(.empty_reducing_end_annotation_data())

--- a/R/internal-cartoon.R
+++ b/R/internal-cartoon.R
@@ -169,7 +169,7 @@
 #'   glycan-structure object.
 #' @param orient Drawing orientation, one of `"left"`, `"right"`, `"up"`, or
 #'   `"down"`.
-#' @param red_end A non-missing string reducing-end annotation.
+#' @param red_end A non-missing string reducing-end annotation or `NULL`.
 #'
 #' @returns A list with `structure`, an igraph glycan graph; `coor`, a numeric
 #'   coordinate matrix with columns `x` and `y`; `highlight`, the validated or
@@ -181,7 +181,7 @@
   orient = c("left", "right", "up", "down"),
   red_end = ""
 ) {
-  checkmate::assert_string(red_end, na.ok = FALSE)
+  checkmate::assert_string(red_end, na.ok = FALSE, null.ok = TRUE)
   if (!is.null(highlight) && !glyrepr::is_glycan_structure(structure)) {
     cli::cli_warn(
       "{.arg highlight} can only be set when {.arg structure} is a {.fn glyrepr::glycan_structure}."
@@ -452,7 +452,7 @@
 #' @noRd
 .apply_highlight_to_annotations <- function(annotation, highlight = NULL) {
   if (is.null(highlight)) {
-    annotation$transparency <- 1
+    annotation$transparency <- rep(1, nrow(annotation))
   } else {
     annotation$transparency <- (annotation$vertice %in% highlight) * 0.7 + 0.3
   }
@@ -536,7 +536,7 @@
     end_y = gly_connect$end_y
   )
   connect_df <- dplyr::bind_rows(connect_df, reducing_segment)
-  connect_df$transparency <- gly_list$transparency
+  connect_df$transparency <- gly_list$transparency[seq_len(nrow(connect_df))]
   connect_df
 }
 

--- a/R/scale-glycan.R
+++ b/R/scale-glycan.R
@@ -39,7 +39,8 @@
 #' @param show_linkage Whether to show glycosidic linkage annotations inside
 #'   the cartoons. Defaults to `TRUE`.
 #' @param red_end Reducing-end annotation passed to [glycanGrob()]. Use `"~"`
-#'   for a wave, or another string to display that text. Defaults to `""`.
+#'   for a wave, another string to display that text, or `NULL` to omit the
+#'   reducing-end line and anomer annotation. Defaults to `""`.
 #' @param fuc_orient Fuc-like triangle orientation passed to [glycanGrob()].
 #' @param edge_linewidth Linkage linewidth passed to [glycanGrob()].
 #' @param node_linewidth Node-border linewidth passed to [glycanGrob()].
@@ -379,7 +380,7 @@ scale_y_glycan <- function(
   checkmate::assert_number(nudge_y, finite = TRUE)
   checkmate::assert_number(edge_linewidth, lower = 0)
   checkmate::assert_number(node_linewidth, lower = 0)
-  checkmate::assert_string(red_end, na.ok = FALSE)
+  checkmate::assert_string(red_end, na.ok = FALSE, null.ok = TRUE)
   checkmate::assert_string(font_family, na.ok = FALSE)
   .validate_node_size(node_size)
   colors <- .validate_custom_colors(colors)

--- a/man/anno_glycan.Rd
+++ b/man/anno_glycan.Rd
@@ -62,7 +62,8 @@ values move cartoons upward. Defaults to \code{0}.}
 the cartoons. Defaults to \code{TRUE}.}
 
 \item{red_end}{Reducing-end annotation passed to \code{\link[=glycanGrob]{glycanGrob()}}. Use \code{"~"}
-for a wave, or another string to display that text. Defaults to \code{""}.}
+for a wave, another string to display that text, or \code{NULL} to omit the
+reducing-end line and anomer annotation. Defaults to \code{""}.}
 
 \item{fuc_orient}{Fuc-like triangle orientation passed to \code{\link[=glycanGrob]{glycanGrob()}}.}
 

--- a/man/draw_cartoon.Rd
+++ b/man/draw_cartoon.Rd
@@ -39,7 +39,8 @@ Fuc-like residues always point upward. Defaults to \code{"flex"}.}
 
 \item{red_end}{Reducing-end annotation. The default \code{""} keeps the current
 reducing-end line. Use \code{"~"} to add a wavy reducing end, or any other
-string to draw that string at the reducing end.}
+string to draw that string at the reducing end. Use \code{NULL} to omit the
+reducing-end line and anomer annotation.}
 
 \item{edge_linewidth}{Numeric scalar controlling the linewidth of linkage
 lines. Defaults to the current value, \code{0.8}.}

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -52,7 +52,8 @@ Fuc-like residues always point upward. Defaults to \code{"flex"}.}
 
 \item{red_end}{Reducing-end annotation. The default \code{""} keeps the current
 reducing-end line. Use \code{"~"} to add a wavy reducing end, or any other
-string to draw that string at the reducing end.}
+string to draw that string at the reducing end. Use \code{NULL} to omit the
+reducing-end line and anomer annotation.}
 
 \item{edge_linewidth}{Numeric scalar controlling the linewidth of linkage
 lines. Defaults to the current value, \code{0.8}.}

--- a/man/geom_glycan.Rd
+++ b/man/geom_glycan.Rd
@@ -60,7 +60,8 @@ Fuc-like residues always point upward. Defaults to \code{"flex"}.}
 
 \item{red_end}{Reducing-end annotation. The default \code{""} keeps the current
 reducing-end line. Use \code{"~"} to add a wavy reducing end, or any other
-string to draw that string at the reducing end.}
+string to draw that string at the reducing end. Use \code{NULL} to omit the
+reducing-end line and anomer annotation.}
 
 \item{edge_linewidth}{Numeric scalar controlling the linewidth of linkage
 lines. Defaults to the current value, \code{0.8}.}

--- a/man/glycanGrob.Rd
+++ b/man/glycanGrob.Rd
@@ -39,7 +39,8 @@ Fuc-like residues always point upward. Defaults to \code{"flex"}.}
 
 \item{red_end}{Reducing-end annotation. The default \code{""} keeps the current
 reducing-end line. Use \code{"~"} to add a wavy reducing end, or any other
-string to draw that string at the reducing end.}
+string to draw that string at the reducing end. Use \code{NULL} to omit the
+reducing-end line and anomer annotation.}
 
 \item{edge_linewidth}{Numeric scalar controlling the linewidth of linkage
 lines. Defaults to the current value, \code{0.8}.}

--- a/man/glydraw_style.Rd
+++ b/man/glydraw_style.Rd
@@ -24,7 +24,8 @@ one of \code{"left"}, \code{"right"}, \code{"up"}, or \code{"down"}. Defaults to
 
 \item{fuc_orient}{Fuc-like triangle orientation: \code{"flex"} or \code{"up"}.}
 
-\item{red_end}{Reducing-end annotation. Use \code{"~"} for a wave.}
+\item{red_end}{Reducing-end annotation. Use \code{"~"} for a wave or \code{NULL} to
+omit the reducing-end line and anomer annotation.}
 
 \item{edge_linewidth}{Linewidth of glycosidic linkages.}
 

--- a/man/guide_glycan.Rd
+++ b/man/guide_glycan.Rd
@@ -81,7 +81,8 @@ cartoons and \code{0.5} for vertical cartoons.}
 the cartoons. Defaults to \code{TRUE}.}
 
 \item{red_end}{Reducing-end annotation passed to \code{\link[=glycanGrob]{glycanGrob()}}. Use \code{"~"}
-for a wave, or another string to display that text. Defaults to \code{""}.}
+for a wave, another string to display that text, or \code{NULL} to omit the
+reducing-end line and anomer annotation. Defaults to \code{""}.}
 
 \item{fuc_orient}{Fuc-like triangle orientation passed to \code{\link[=glycanGrob]{glycanGrob()}}.}
 

--- a/man/scale_x_glycan.Rd
+++ b/man/scale_x_glycan.Rd
@@ -99,7 +99,8 @@ to \code{0}.}
 the cartoons. Defaults to \code{TRUE}.}
 
 \item{red_end}{Reducing-end annotation passed to \code{\link[=glycanGrob]{glycanGrob()}}. Use \code{"~"}
-for a wave, or another string to display that text. Defaults to \code{""}.}
+for a wave, another string to display that text, or \code{NULL} to omit the
+reducing-end line and anomer annotation. Defaults to \code{""}.}
 
 \item{fuc_orient}{Fuc-like triangle orientation passed to \code{\link[=glycanGrob]{glycanGrob()}}.}
 

--- a/tests/testthat/test-draw-cartoon.R
+++ b/tests/testthat/test-draw-cartoon.R
@@ -210,6 +210,22 @@ test_that("reducing-end beta annotations follow the physical edge direction", {
   })
 })
 
+test_that("red_end = NULL omits the complete reducing end", {
+  structure <- "Gal(b1-3)GalNAc(a1-"
+  grob <- glycanGrob(structure, red_end = NULL)
+  single_residue_grob <- glycanGrob("GlcNAc(b1-", red_end = NULL)
+  reducing_info <- grob$annotation_data$reducing_info
+
+  expect_null(glydraw_style(red_end = NULL)$red_end)
+  expect_equal(
+    vapply(reducing_info, nrow, integer(1)),
+    c(annotation = 0L, segment = 0L, wave = 0L, bounds = 0L)
+  )
+  expect_equal(nrow(grob$connect_df), 1)
+  expect_equal(nrow(single_residue_grob$connect_df), 0)
+  expect_s3_class(draw_cartoon(structure, red_end = NULL), "glydraw_cartoon")
+})
+
 test_that("draw_cartoon applies custom monosaccharide colors over defaults", {
   structure <- "Gal(b1-4)GlcNAc(b1-"
 

--- a/tests/testthat/test-scale-glycan.R
+++ b/tests/testthat/test-scale-glycan.R
@@ -449,8 +449,16 @@ test_that("glycan axis labels support reducing-end annotations", {
   ) +
     ggplot2::geom_col() +
     scale_y_glycan(red_end = "Reducing end")
+  no_red_end_plot <- ggplot2::ggplot(
+    data,
+    ggplot2::aes(x = .data$structure, y = .data$value)
+  ) +
+    ggplot2::geom_col() +
+    scale_x_glycan(red_end = NULL)
   x_label <- .axis_glycan_labels(x_plot, "axis-b")$children[[1]]
   y_label <- .axis_glycan_labels(y_plot, "axis-l")$children[[1]]
+  no_red_end_label <-
+    .axis_glycan_labels(no_red_end_plot, "axis-b")$children[[1]]
 
   expect_gt(nrow(x_label$annotation_data$reducing_info$wave), 0)
   expect_true(any(
@@ -459,6 +467,14 @@ test_that("glycan axis labels support reducing-end annotations", {
   expect_match(
     y_label$annotation_data$reducing_info$annotation$annot[[2]],
     "Reducing end"
+  )
+  expect_equal(
+    vapply(
+      no_red_end_label$annotation_data$reducing_info,
+      nrow,
+      integer(1)
+    ),
+    c(annotation = 0L, segment = 0L, wave = 0L, bounds = 0L)
   )
 })
 


### PR DESCRIPTION
## Summary

- Allow `red_end = NULL` to omit both the reducing-end line and anomer annotation across glycan drawing interfaces.
- Handle empty annotations and segments, including single-residue glycans and glycan axis labels.
- Document the new behavior and add regression coverage.

## Verification

- `devtools::test()` — 486 passed
- `devtools::check()` — 0 errors, 0 warnings, 1 environment clock-verification note
- `git diff --check`