### PR TITLE
Fix same-edge linkage annotation collision detection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,9 +22,7 @@
 
 ## Minor improvements and bug fixes
 
-* Linkage-annotation collision handling now ignores the two labels belonging to
-  the same edge, preventing enlarged nodes from unnecessarily reflecting an
-  otherwise collision-free linkage.
+* Linkage-annotation collision handling now ignores the two labels belonging to the same edge, preventing enlarged nodes from unnecessarily reflecting an otherwise collision-free linkage. (#75)
 
 * `style_glydraw(node_size = ...)` now distributes linkage-annotation spacing adjustments across the node-to-label and label-to-label gaps, keeping linkage notation readable with enlarged nodes. (#74)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,10 @@
 
 ## Minor improvements and bug fixes
 
+* Linkage-annotation collision handling now ignores the two labels belonging to
+  the same edge, preventing enlarged nodes from unnecessarily reflecting an
+  otherwise collision-free linkage.
+
 * `style_glydraw(node_size = ...)` now distributes linkage-annotation spacing adjustments across the node-to-label and label-to-label gaps, keeping linkage notation readable with enlarged nodes. (#74)
 
 * `red_end = NULL` now omits both the reducing-end line and its anomer annotation across glycan drawing interfaces. (#71)

--- a/R/internal-annotations.R
+++ b/R/internal-annotations.R
@@ -618,17 +618,29 @@
 #' Find the shortest distance among annotation coordinates
 #'
 #' @param coords A numeric matrix with columns `x` and `y`.
+#' @param group_keys A character vector mapping rows to linkage groups.
+#'   Distances within the same non-missing group are ignored.
 #'
 #' @returns A numeric scalar minimum pairwise Euclidean distance among complete
-#'   rows. Returns `Inf` when fewer than two complete rows are available.
+#'   rows from different groups. Returns `Inf` when fewer than two eligible rows
+#'   are available.
 #' @noRd
-.minimum_annotation_distance <- function(coords) {
+.minimum_annotation_distance <- function(
+  coords,
+  group_keys = rep(NA_character_, nrow(coords))
+) {
   finite <- stats::complete.cases(coords)
   if (sum(finite) < 2) {
     return(Inf)
   }
 
-  min(stats::dist(coords[finite, , drop = FALSE]))
+  distances <- as.matrix(stats::dist(coords[finite, , drop = FALSE]))
+  finite_groups <- group_keys[finite]
+  same_group <- outer(finite_groups, finite_groups, "==")
+  same_group[is.na(same_group)] <- FALSE
+  distances[same_group] <- Inf
+  diag(distances) <- Inf
+  min(distances)
 }
 
 #' Check whether two annotation rows are sufficiently separated
@@ -740,7 +752,7 @@
       candidate_coords <- coords
       rows <- groups$rows[[candidate]]
       candidate_coords[rows, ] <- reflected_coords[rows, ]
-      .minimum_annotation_distance(candidate_coords)
+      .minimum_annotation_distance(candidate_coords, groups$keys)
     }
   )
 
@@ -849,6 +861,12 @@
   for (pair in seq_len(nrow(pairs))) {
     i <- pairs$i[pair]
     j <- pairs$j[pair]
+    same_group <- !is.na(groups$keys[[i]]) &&
+      !is.na(groups$keys[[j]]) &&
+      groups$keys[[i]] == groups$keys[[j]]
+    if (same_group) {
+      next
+    }
     if (.annotations_are_separated(coords, i, j, min_distance)) {
       next
     }

--- a/tests/testthat/test-draw-cartoon.R
+++ b/tests/testthat/test-draw-cartoon.R
@@ -194,6 +194,63 @@ test_that("larger nodes shorten all three linkage annotation gaps", {
   )
 })
 
+test_that("labels on one linkage do not collide with each other", {
+  inputs <- .prepare_cartoon_inputs(
+    "Gal(b1-3)GalNAc(a1-",
+    NULL,
+    "left",
+    "~"
+  )
+  annotation <- .linkage_annotation_data(
+    inputs$structure,
+    inputs$coor,
+    node_size = 1.3,
+    orient = "left"
+  )
+
+  separated <- .separate_overlapping_annotations(annotation)
+
+  expect_equal(separated[, c("x", "y")], annotation[, c("x", "y")])
+})
+
+test_that("overlapping labels on different linkages reflect as a group", {
+  glycan <- paste0(
+    "Neu5Ac(a2-3)Gal(b1-3)[Neu5Ac(a2-3)Gal(b1-4)",
+    "[Fuc(a1-3)]GlcNAc(b1-6)]GalNAc(a1-"
+  )
+  inputs <- .prepare_cartoon_inputs(glycan, NULL, "left", "~")
+  annotation <- .linkage_annotation_data(
+    inputs$structure,
+    inputs$coor,
+    orient = "left"
+  )
+  reflected_rows <- which(
+    annotation$vertice == "4" &
+      annotation$annot %in% c("beta", "6")
+  )
+  segment <- as.matrix(annotation[, c(
+    "segment_start_x",
+    "segment_start_y",
+    "segment_end_x",
+    "segment_end_y"
+  )])
+  reflected <- .reflected_annotation_coordinates(
+    as.matrix(annotation[, c("x", "y")]),
+    segment
+  )
+
+  separated <- .separate_overlapping_annotations(annotation)
+
+  expect_equal(
+    unname(as.matrix(separated[reflected_rows, c("x", "y")])),
+    unname(reflected[reflected_rows, ])
+  )
+  expect_equal(
+    separated[-reflected_rows, c("x", "y")],
+    annotation[-reflected_rows, c("x", "y")]
+  )
+})
+
 test_that("reducing-end beta annotations follow the physical edge direction", {
   purrr::walk(c("left", "right", "up", "down"), function(orient) {
     beta_inputs <- .prepare_cartoon_inputs(


### PR DESCRIPTION
## Summary

- Ignore distances between linkage labels belonging to the same edge during collision detection.
- Exclude same-edge distances when selecting which competing linkage to reflect.
- Preserve cross-edge collision handling and add regressions for both the simple and crowded glycan cases.

## Verification

- `Rscript -e 'devtools::test()'` — 526 tests passed.
- `R CMD check --no-manual` — Status: OK.
- Verified `Gal(b1-3)GalNAc(a1-` keeps its linkage labels below the edge with `style_glygen(node_size = 1.3)`.
- Verified the crowded branched glycan still reflects the `β6` annotation pair.