### PR TITLE
Add explicit red_end overrides to drawing APIs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * `glydraw_style()` has been renamed to `style_glydraw()` and is no longer exported; replace calls to `glydraw_style()` with `style_glydraw()`. (#73)
 
-* Cartoon appearance is now configured only with `style = style_glydraw(...)` across `draw_cartoon()`, `glycanGrob()`, `geom_glycan()`, `guide_glycan()`, `scale_x_glycan()`, `scale_y_glycan()`, `anno_glycan()`, and `export_cartoons()`; calls that pass `fuc_orient`, `red_end`, `edge_linewidth`, `node_linewidth`, `node_size`, `font_family`, or `colors` directly should move those arguments into `style_glydraw()`, while `show_linkage` and `orient` remain explicit arguments and are no longer accepted by `style_glydraw()`. (#73)
+* Cartoon appearance is now configured with `style = style_glydraw(...)` across `draw_cartoon()`, `glycanGrob()`, `geom_glycan()`, `guide_glycan()`, `scale_x_glycan()`, `scale_y_glycan()`, `anno_glycan()`, and `export_cartoons()`; calls that pass `fuc_orient`, `edge_linewidth`, `node_linewidth`, `node_size`, `font_family`, or `colors` directly should move those arguments into `style_glydraw()`. `show_linkage` and `orient` remain explicit arguments and are no longer accepted by `style_glydraw()`, while explicit `red_end` overrides the reusable style value. (#73)
 
 * The shared `orient` argument no longer accepts `"H"` or `"V"`; calls using them now error and should replace `"H"` with `"left"` and `"V"` with `"up"`. (#68)
 
@@ -12,7 +12,7 @@
 
 * New `draw_cartoon_sketch()` draws hand-sketched glycan cartoons with reproducible rough strokes, patterned residue fills, optional drawing media, and the same layout, annotation, orientation, highlighting, styling, sizing, and saving behavior as `draw_cartoon()`. (#77)
 
-* `style_glydraw()` replaces `glydraw_style()` as the single reusable interface for tuning cartoon appearance; `show_linkage` and `orient` are explicit drawing controls instead of style fields, while new `style_glygen()`, `style_snfg()`, and `style_glycoworkbench()` provide reusable presets for common glycan-drawing conventions. (#73)
+* `style_glydraw()` replaces `glydraw_style()` as the single reusable interface for tuning cartoon appearance; `show_linkage` and `orient` are explicit drawing controls instead of style fields, and explicit `red_end = NULL` inherits the style value. New `style_glygen()`, `style_snfg()`, and `style_glycoworkbench()` provide reusable presets for common glycan-drawing conventions. (#73)
 
 * New `font_family` style option controls the font used for text annotations across glycan cartoons, including alpha and beta anomer labels. (#69)
 
@@ -30,7 +30,7 @@
 
 * `style_glydraw(node_size = ...)` now distributes linkage-annotation spacing adjustments across the node-to-label and label-to-label gaps, keeping linkage notation readable with enlarged nodes. (#74)
 
-* `red_end = NULL` now omits both the reducing-end line and its anomer annotation across glycan drawing interfaces. (#71)
+* `style_glydraw(red_end = NULL)` now omits both the reducing-end line and its anomer annotation across glycan drawing interfaces. (#71)
 
 * Move beta linkage annotations slightly away from horizontal and skewed edge lines while leaving labels beside vertical edges unchanged, including reducing-end annotations. (#70)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * `glydraw_style()` has been renamed to `style_glydraw()` and is no longer exported; replace calls to `glydraw_style()` with `style_glydraw()`. (#73)
 
-* Cartoon appearance is now configured with `style = style_glydraw(...)` across `draw_cartoon()`, `glycanGrob()`, `geom_glycan()`, `guide_glycan()`, `scale_x_glycan()`, `scale_y_glycan()`, `anno_glycan()`, and `export_cartoons()`; calls that pass `fuc_orient`, `edge_linewidth`, `node_linewidth`, `node_size`, `font_family`, or `colors` directly should move those arguments into `style_glydraw()`. `show_linkage` and `orient` remain explicit arguments and are no longer accepted by `style_glydraw()`, while explicit `red_end` overrides the reusable style value. (#73)
+* Cartoon appearance is now configured with `style = style_glydraw(...)` across `draw_cartoon()`, `glycanGrob()`, `geom_glycan()`, `guide_glycan()`, `scale_x_glycan()`, `scale_y_glycan()`, `anno_glycan()`, and `export_cartoons()`; calls that pass `fuc_orient`, `edge_linewidth`, `node_linewidth`, `node_size`, `font_family`, or `colors` directly should move those arguments into `style_glydraw()`. `show_linkage` and `orient` remain explicit arguments and are no longer accepted by `style_glydraw()`, while explicit `red_end` overrides the reusable style value. (#73, #79)
 
 * The shared `orient` argument no longer accepts `"H"` or `"V"`; calls using them now error and should replace `"H"` with `"left"` and `"V"` with `"up"`. (#68)
 
@@ -12,7 +12,7 @@
 
 * New `draw_cartoon_sketch()` draws hand-sketched glycan cartoons with reproducible rough strokes, patterned residue fills, optional drawing media, and the same layout, annotation, orientation, highlighting, styling, sizing, and saving behavior as `draw_cartoon()`. (#77)
 
-* `style_glydraw()` replaces `glydraw_style()` as the single reusable interface for tuning cartoon appearance; `show_linkage` and `orient` are explicit drawing controls instead of style fields, and explicit `red_end = NULL` inherits the style value. New `style_glygen()`, `style_snfg()`, and `style_glycoworkbench()` provide reusable presets for common glycan-drawing conventions. (#73)
+* `style_glydraw()` replaces `glydraw_style()` as the single reusable interface for tuning cartoon appearance; `show_linkage` and `orient` are explicit drawing controls instead of style fields, and explicit `red_end = NULL` inherits the style value. New `style_glygen()`, `style_snfg()`, and `style_glycoworkbench()` provide reusable presets for common glycan-drawing conventions. (#73, #79)
 
 * New `font_family` style option controls the font used for text annotations across glycan cartoons, including alpha and beta anomer labels. (#69)
 

--- a/R/anno-glycan.R
+++ b/R/anno-glycan.R
@@ -42,6 +42,8 @@
 #'   the cartoons. Defaults to `TRUE`.
 #' @param style A [style_glydraw()] object that controls the cartoons' visual
 #'   appearance.
+#' @param red_end Reducing-end annotation. `NULL`, the default, uses `red_end`
+#'   from `style`. A non-`NULL` value overrides `style$red_end`.
 #' @param width Optional [grid::unit()] width for a row annotation. `NULL`
 #'   calculates the width from the rendered cartoons.
 #' @param height Optional [grid::unit()] height for a column annotation. `NULL`
@@ -92,7 +94,8 @@ anno_glycan <- function(
   style = style_glydraw(),
   width = NULL,
   height = NULL,
-  show_name = FALSE
+  show_name = FALSE,
+  red_end = NULL
 ) {
   if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
     cli::cli_abort(
@@ -110,6 +113,7 @@ anno_glycan <- function(
     vjust <- switch(which, column = 0, row = vjust_red_end())
   }
   checkmate::assert_flag(show_name)
+  red_end <- .resolve_red_end(red_end, style)
 
   options <- .validate_glycan_label_options(
     orient = orient,
@@ -120,7 +124,7 @@ anno_glycan <- function(
     nudge_x = nudge_x,
     nudge_y = nudge_y,
     show_linkage = show_linkage,
-    red_end = style$red_end,
+    red_end = red_end,
     fuc_orient = style$fuc_orient,
     edge_linewidth = style$edge_linewidth,
     node_linewidth = style$node_linewidth,

--- a/R/draw-cartoon-sketch.R
+++ b/R/draw-cartoon-sketch.R
@@ -51,7 +51,8 @@ draw_cartoon_sketch <- function(
   hachure_angle = 45,
   hachure_gap = 0.03,
   fill_weight = 0.5,
-  medium = NULL
+  medium = NULL,
+  red_end = NULL
 ) {
   rlang::check_installed(
     "ggsketch",
@@ -64,7 +65,8 @@ draw_cartoon_sketch <- function(
     show_linkage = show_linkage,
     orient = orient,
     highlight = highlight,
-    style = style
+    style = style,
+    red_end = red_end
   )
   sketch <- list(
     roughness = roughness,

--- a/R/draw-cartoon.R
+++ b/R/draw-cartoon.R
@@ -9,6 +9,8 @@
 #'   one of `"left"`, `"right"`, `"up"`, or `"down"`. Defaults to `"left"`.
 #' @param style A [style_glydraw()] object that controls the cartoon's visual
 #'   appearance.
+#' @param red_end Reducing-end annotation. `NULL`, the default, uses `red_end`
+#'   from `style`. A non-`NULL` value overrides `style$red_end`.
 #' @param highlight An integer vector specifying the node indices to highlight.
 #'   This argument is applicable only when `structure` is a [glyrepr::glycan_structure()].
 #'   Note that for a [glyrepr::glycan_structure()], the node indices correspond exactly
@@ -30,7 +32,8 @@ draw_cartoon <- function(
   show_linkage = TRUE,
   orient = c("left", "right", "up", "down"),
   highlight = NULL,
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 ) {
   glycanGrob(
     structure,
@@ -38,7 +41,8 @@ draw_cartoon <- function(
     show_linkage = show_linkage,
     orient = orient,
     highlight = highlight,
-    style = style
+    style = style,
+    red_end = red_end
   ) |>
     .glycan_grob_to_plot()
 }

--- a/R/export-cartoons.R
+++ b/R/export-cartoons.R
@@ -41,7 +41,8 @@ export_cartoons <- function(
   scale = 1,
   show_linkage = TRUE,
   orient = c("left", "right", "up", "down"),
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 ) {
   if (!missing(dpi)) {
     .warn_ignored_dpi()
@@ -60,7 +61,8 @@ export_cartoons.character <- function(
   scale = 1,
   show_linkage = TRUE,
   orient = c("left", "right", "up", "down"),
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 ) {
   .export_cartoon_list(
     unique(.as_glycan_structure_input(x)),
@@ -69,7 +71,8 @@ export_cartoons.character <- function(
     scale,
     show_linkage,
     orient,
-    style
+    style,
+    red_end
   )
 }
 
@@ -83,7 +86,8 @@ export_cartoons.glyrepr_structure <- function(
   scale = 1,
   show_linkage = TRUE,
   orient = c("left", "right", "up", "down"),
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 ) {
   .export_cartoon_list(
     unique(x),
@@ -92,7 +96,8 @@ export_cartoons.glyrepr_structure <- function(
     scale,
     show_linkage,
     orient,
-    style
+    style,
+    red_end
   )
 }
 
@@ -103,7 +108,8 @@ export_cartoons.glyrepr_structure <- function(
   scale,
   show_linkage,
   orient,
-  style
+  style,
+  red_end
 ) {
   cli::cli_alert_info("Exporting {.val {length(glycans)}} glycan cartoons.")
   fs::dir_create(dirname)
@@ -113,7 +119,8 @@ export_cartoons.glyrepr_structure <- function(
     draw_cartoon,
     show_linkage = show_linkage,
     orient = orient,
-    style = style
+    style = style,
+    red_end = red_end
   )
   filenames <- fs::path(
     dirname,

--- a/R/geom-glycan.R
+++ b/R/geom-glycan.R
@@ -155,9 +155,11 @@ geom_glycan <- function(
   style = style_glydraw(),
   na.rm = FALSE,
   show.legend = NA,
-  inherit.aes = TRUE
+  inherit.aes = TRUE,
+  red_end = NULL
 ) {
   orient <- rlang::arg_match(orient)
+  red_end <- .resolve_red_end(red_end, style)
   show_linkage <- .resolve_linkage_visibility(
     show_linkage,
     style$node_size
@@ -167,7 +169,7 @@ geom_glycan <- function(
     show_linkage = show_linkage,
     orient = orient,
     fuc_orient = style$fuc_orient,
-    red_end = style$red_end,
+    red_end = red_end,
     edge_linewidth = style$edge_linewidth,
     node_linewidth = style$node_linewidth,
     node_size = style$node_size,

--- a/R/glycan-grob.R
+++ b/R/glycan-grob.R
@@ -20,13 +20,15 @@ glycanGrob <- function(
   show_linkage = TRUE,
   orient = c("left", "right", "up", "down"),
   highlight = NULL,
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 ) {
   orient <- rlang::arg_match(orient, error_call = NULL)
   checkmate::assert_class(style, "glydraw_style")
+  red_end <- .resolve_red_end(red_end, style)
   style <- .make_glydraw_style(
     fuc_orient = style$fuc_orient,
-    red_end = style$red_end,
+    red_end = red_end,
     edge_linewidth = style$edge_linewidth,
     node_linewidth = style$node_linewidth,
     node_size = style$node_size,

--- a/R/guide-glycan.R
+++ b/R/guide-glycan.R
@@ -23,6 +23,8 @@
 #'   the cartoons. Defaults to `TRUE`.
 #' @param style A [style_glydraw()] object that controls the cartoons' visual
 #'   appearance.
+#' @param red_end Reducing-end annotation. `NULL`, the default, uses `red_end`
+#'   from `style`. A non-`NULL` value overrides `style$red_end`.
 #'
 #' @returns A ggplot2 legend guide that draws glycan cartoons in place of text
 #'   labels.
@@ -62,7 +64,8 @@ guide_glycan <- function(
   hjust = 0,
   vjust = vjust_red_end(),
   show_linkage = TRUE,
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 ) {
   hjust_is_missing <- missing(hjust)
   vjust_is_missing <- missing(vjust)
@@ -77,6 +80,7 @@ guide_glycan <- function(
   .validate_red_end_justification_orientation(hjust, vjust, orient)
   .validate_glycan_justification_scalar(hjust, "hjust")
   .validate_glycan_justification_scalar(vjust, "vjust")
+  red_end <- .resolve_red_end(red_end, style)
   show_linkage <- .resolve_linkage_visibility(
     show_linkage,
     style$node_size
@@ -112,7 +116,7 @@ guide_glycan <- function(
     glycan_hjust = hjust,
     glycan_vjust = vjust,
     glycan_show_linkage = show_linkage,
-    glycan_red_end = style$red_end,
+    glycan_red_end = red_end,
     glycan_fuc_orient = style$fuc_orient,
     glycan_edge_linewidth = style$edge_linewidth,
     glycan_node_linewidth = style$node_linewidth,

--- a/R/scale-glycan.R
+++ b/R/scale-glycan.R
@@ -40,6 +40,8 @@
 #'   the cartoons. Defaults to `TRUE`.
 #' @param style A [style_glydraw()] object that controls the cartoons' visual
 #'   appearance.
+#' @param red_end Reducing-end annotation. `NULL`, the default, uses `red_end`
+#'   from `style`. A non-`NULL` value overrides `style$red_end`.
 #'
 #' @returns A ggplot2 discrete position scale.
 #'
@@ -71,8 +73,10 @@ scale_x_glycan <- function(
   nudge_x = 0,
   nudge_y = 0,
   show_linkage = TRUE,
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 ) {
+  red_end <- .resolve_red_end(red_end, style)
   guide <- .new_glycan_axis_guide(
     orient = "up",
     size = size,
@@ -82,7 +86,7 @@ scale_x_glycan <- function(
     nudge_x = nudge_x,
     nudge_y = nudge_y,
     show_linkage = show_linkage,
-    red_end = style$red_end,
+    red_end = red_end,
     fuc_orient = style$fuc_orient,
     edge_linewidth = style$edge_linewidth,
     node_linewidth = style$node_linewidth,
@@ -122,8 +126,10 @@ scale_y_glycan <- function(
   nudge_x = 0,
   nudge_y = 0,
   show_linkage = TRUE,
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 ) {
+  red_end <- .resolve_red_end(red_end, style)
   guide <- .new_glycan_axis_guide(
     orient = "left",
     size = size,
@@ -133,7 +139,7 @@ scale_y_glycan <- function(
     nudge_x = nudge_x,
     nudge_y = nudge_y,
     show_linkage = show_linkage,
-    red_end = style$red_end,
+    red_end = red_end,
     fuc_orient = style$fuc_orient,
     edge_linewidth = style$edge_linewidth,
     node_linewidth = style$node_linewidth,

--- a/R/style-glydraw.R
+++ b/R/style-glydraw.R
@@ -158,3 +158,11 @@ style_glycoworkbench <- function(
     class = "glydraw_style"
   )
 }
+
+.resolve_red_end <- function(red_end, style) {
+  if (is.null(red_end)) {
+    return(style$red_end)
+  }
+  checkmate::assert_string(red_end, na.ok = FALSE)
+  red_end
+}

--- a/man/anno_glycan.Rd
+++ b/man/anno_glycan.Rd
@@ -18,7 +18,8 @@ anno_glycan(
   style = style_glydraw(),
   width = NULL,
   height = NULL,
-  show_name = FALSE
+  show_name = FALSE,
+  red_end = NULL
 )
 }
 \arguments{
@@ -66,6 +67,9 @@ calculates the height from the rendered cartoons.}
 \item{show_name}{Whether ComplexHeatmap should show the annotation name.
 Defaults to \code{FALSE} because the cartoons normally replace row or column
 names.}
+
+\item{red_end}{Reducing-end annotation. \code{NULL}, the default, uses \code{red_end}
+from \code{style}. A non-\code{NULL} value overrides \code{style$red_end}.}
 }
 \value{
 A ComplexHeatmap \code{AnnotationFunction} object.

--- a/man/draw_cartoon.Rd
+++ b/man/draw_cartoon.Rd
@@ -10,7 +10,8 @@ draw_cartoon(
   show_linkage = TRUE,
   orient = c("left", "right", "up", "down"),
   highlight = NULL,
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 )
 }
 \arguments{
@@ -34,6 +35,9 @@ setting \code{highlight = c(1, 3)} will highlight the "Gal" and "GalNAc" nodes.}
 
 \item{style}{A \code{\link[=style_glydraw]{style_glydraw()}} object that controls the cartoon's visual
 appearance.}
+
+\item{red_end}{Reducing-end annotation. \code{NULL}, the default, uses \code{red_end}
+from \code{style}. A non-\code{NULL} value overrides \code{style$red_end}.}
 }
 \value{
 a ggplot2 object

--- a/man/draw_cartoon_sketch.Rd
+++ b/man/draw_cartoon_sketch.Rd
@@ -19,7 +19,8 @@ draw_cartoon_sketch(
   hachure_angle = 45,
   hachure_gap = 0.03,
   fill_weight = 0.5,
-  medium = NULL
+  medium = NULL,
+  red_end = NULL
 )
 }
 \arguments{
@@ -67,6 +68,9 @@ node diameter. Defaults to \code{0.03}.}
 
 \item{medium}{Optional drawing medium for linkage and reducing-end strokes.
 See \code{\link[ggsketch:sketch_media]{ggsketch::sketch_media()}} for the available media.}
+
+\item{red_end}{Reducing-end annotation. \code{NULL}, the default, uses \code{red_end}
+from \code{style}. A non-\code{NULL} value overrides \code{style$red_end}.}
 }
 \value{
 A \code{glydraw_cartoon} ggplot2 object.

--- a/man/export_cartoons.Rd
+++ b/man/export_cartoons.Rd
@@ -13,7 +13,8 @@ export_cartoons(
   scale = 1,
   show_linkage = TRUE,
   orient = c("left", "right", "up", "down"),
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 )
 }
 \arguments{
@@ -40,6 +41,9 @@ one of \code{"left"}, \code{"right"}, \code{"up"}, or \code{"down"}. Defaults to
 
 \item{style}{A \code{\link[=style_glydraw]{style_glydraw()}} object that controls the cartoon's visual
 appearance.}
+
+\item{red_end}{Reducing-end annotation. \code{NULL}, the default, uses \code{red_end}
+from \code{style}. A non-\code{NULL} value overrides \code{style$red_end}.}
 }
 \value{
 The function returns the list of cartoons implicitly.

--- a/man/geom_glycan.Rd
+++ b/man/geom_glycan.Rd
@@ -17,7 +17,8 @@ geom_glycan(
   style = style_glydraw(),
   na.rm = FALSE,
   show.legend = NA,
-  inherit.aes = TRUE
+  inherit.aes = TRUE,
+  red_end = NULL
 )
 }
 \arguments{
@@ -63,6 +64,9 @@ warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics rather than
 combining with them.}
+
+\item{red_end}{Reducing-end annotation. \code{NULL}, the default, uses \code{red_end}
+from \code{style}. A non-\code{NULL} value overrides \code{style$red_end}.}
 }
 \value{
 A ggplot2 layer that can be added to a \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}} object.

--- a/man/glycanGrob.Rd
+++ b/man/glycanGrob.Rd
@@ -10,7 +10,8 @@ glycanGrob(
   show_linkage = TRUE,
   orient = c("left", "right", "up", "down"),
   highlight = NULL,
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 )
 }
 \arguments{
@@ -34,6 +35,9 @@ setting \code{highlight = c(1, 3)} will highlight the "Gal" and "GalNAc" nodes.}
 
 \item{style}{A \code{\link[=style_glydraw]{style_glydraw()}} object that controls the cartoon's visual
 appearance.}
+
+\item{red_end}{Reducing-end annotation. \code{NULL}, the default, uses \code{red_end}
+from \code{style}. A non-\code{NULL} value overrides \code{style$red_end}.}
 }
 \value{
 A \code{glycanGrob} object inheriting from \code{\link[grid:grid.grob]{grid::gTree()}}.

--- a/man/guide_glycan.Rd
+++ b/man/guide_glycan.Rd
@@ -19,7 +19,8 @@ guide_glycan(
   hjust = 0,
   vjust = vjust_red_end(),
   show_linkage = TRUE,
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 )
 }
 \arguments{
@@ -75,6 +76,9 @@ the cartoons. Defaults to \code{TRUE}.}
 
 \item{style}{A \code{\link[=style_glydraw]{style_glydraw()}} object that controls the cartoons' visual
 appearance.}
+
+\item{red_end}{Reducing-end annotation. \code{NULL}, the default, uses \code{red_end}
+from \code{style}. A non-\code{NULL} value overrides \code{style$red_end}.}
 }
 \value{
 A ggplot2 legend guide that draws glycan cartoons in place of text

--- a/man/scale_x_glycan.Rd
+++ b/man/scale_x_glycan.Rd
@@ -20,7 +20,8 @@ scale_x_glycan(
   nudge_x = 0,
   nudge_y = 0,
   show_linkage = TRUE,
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 )
 
 scale_y_glycan(
@@ -38,7 +39,8 @@ scale_y_glycan(
   nudge_x = 0,
   nudge_y = 0,
   show_linkage = TRUE,
-  style = style_glydraw()
+  style = style_glydraw(),
+  red_end = NULL
 )
 }
 \arguments{
@@ -86,6 +88,9 @@ the cartoons. Defaults to \code{TRUE}.}
 
 \item{style}{A \code{\link[=style_glydraw]{style_glydraw()}} object that controls the cartoons' visual
 appearance.}
+
+\item{red_end}{Reducing-end annotation. \code{NULL}, the default, uses \code{red_end}
+from \code{style}. A non-\code{NULL} value overrides \code{style$red_end}.}
 }
 \value{
 A ggplot2 discrete position scale.

--- a/tests/testthat/test-anno-glycan.R
+++ b/tests/testthat/test-anno-glycan.R
@@ -195,6 +195,19 @@ test_that("anno_glycan supports scale label adjustments and styles", {
   expect_equal(positioned$vp$angle, -45)
 })
 
+test_that("anno_glycan red_end overrides its style", {
+  skip_if_not_installed("ComplexHeatmap")
+  annotation <- anno_glycan(
+    "Gal(b1-3)GalNAc(a1-",
+    style = style_glydraw(red_end = "~"),
+    red_end = "Reducing end"
+  )
+  reducing_annotation <-
+    annotation@var_env$grobs[[1]]$annotation_data$reducing_info$annotation
+
+  expect_match(reducing_annotation$annot[[2]], "Reducing end")
+})
+
 test_that("anno_glycan sizes rotated and nudged labels like glycan scales", {
   skip_if_not_installed("ComplexHeatmap")
   grDevices::pdf(NULL)

--- a/tests/testthat/test-draw-cartoon-sketch.R
+++ b/tests/testthat/test-draw-cartoon-sketch.R
@@ -81,6 +81,23 @@ test_that("sketch text unquotes custom reducing-end labels", {
   )
 })
 
+test_that("draw_cartoon_sketch red_end overrides its style", {
+  plot <- draw_cartoon_sketch(
+    "Gal(b1-3)GalNAc(a1-",
+    style = style_glydraw(red_end = "~"),
+    red_end = "Reducing end",
+    seed = 1
+  )
+  text_index <- which(vapply(
+    plot$layers,
+    \(layer) inherits(layer$geom, "GeomText"),
+    logical(1)
+  ))
+  text <- ggplot2::ggplot_build(plot)$data[[text_index]]
+
+  expect_contains(text$label, "Reducing end")
+})
+
 test_that("draw_cartoon_sketch gives each node a reproducible random seed", {
   structure <- paste0(
     "Gal(b1-3)Gal(b1-3)",

--- a/tests/testthat/test-draw-cartoon.R
+++ b/tests/testthat/test-draw-cartoon.R
@@ -351,7 +351,7 @@ test_that("draw_cartoon accepts reusable glydraw styles", {
   expect_contains(unique(styled_layers[[3]]$fill), "#123456")
 })
 
-test_that("cartoon styling is available only through style", {
+test_that("main APIs expose only the red_end style override", {
   expect_setequal(
     intersect(
       getNamespaceExports("glydraw"),
@@ -377,7 +377,7 @@ test_that("cartoon styling is available only through style", {
 
   purrr::walk(
     interface_arguments,
-    ~ expect_false(any(styling_arguments %in% .x))
+    ~ expect_setequal(intersect(styling_arguments, .x), "red_end")
   )
   expect_false(any(c("show_linkage", "orient") %in% styling_arguments))
   expect_true(all(
@@ -402,6 +402,43 @@ test_that("cartoon styling is available only through style", {
     interfaces,
     ~ expect_identical(formals(.x)$style, quote(style_glydraw()))
   )
+  purrr::walk(
+    interfaces,
+    ~ expect_null(formals(.x)$red_end)
+  )
+  purrr::walk(
+    interface_arguments,
+    ~ expect_identical(tail(.x, 1), "red_end")
+  )
+})
+
+test_that("explicit red_end overrides style and NULL inherits it", {
+  structure <- "Gal(b1-3)GalNAc(a1-"
+  style <- style_glydraw(red_end = "~")
+
+  inherited <- glycanGrob(structure, style = style)
+  overridden <- glycanGrob(
+    structure,
+    style = style,
+    red_end = "Reducing end"
+  )
+  drawn <- draw_cartoon(
+    structure,
+    style = style,
+    red_end = "Reducing end"
+  )
+  drawn_annotation <- drawn$layers[["geom_text"]]$data$annot
+
+  expect_gt(nrow(inherited$annotation_data$reducing_info$wave), 0)
+  expect_true(any(
+    overridden$annotation_data$reducing_info$annotation$is_red_end_text
+  ))
+  expect_match(
+    overridden$annotation_data$reducing_info$annotation$annot[[2]],
+    "Reducing end"
+  )
+  expect_contains(drawn_annotation, '"Reducing end"')
+  expect_identical(style$red_end, "~")
 })
 
 test_that("draw_cartoon requires the complete named SNFG palette", {

--- a/tests/testthat/test-export-cartoons.R
+++ b/tests/testthat/test-export-cartoons.R
@@ -64,6 +64,23 @@ test_that("export_cartoons forwards custom linewidths", {
   expect_equal(unique(layers[[3]]$linewidth), 0.3)
 })
 
+test_that("export_cartoons red_end overrides its style", {
+  temp_dir <- tempfile()
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+
+  suppressMessages(
+    result <- export_cartoons(
+      "Gal(b1-3)GalNAc(a1-",
+      temp_dir,
+      style = style_glydraw(red_end = "~"),
+      red_end = "Reducing end"
+    )
+  )
+  annotation <- result[[1]]$layers[["geom_text"]]$data$annot
+
+  expect_contains(annotation, '"Reducing end"')
+})
+
 test_that("export_cartoons forwards custom colors", {
   glycans <- "Gal(b1-4)GlcNAc(b1-"
   temp_dir <- tempfile()

--- a/tests/testthat/test-geom-glycan.R
+++ b/tests/testthat/test-geom-glycan.R
@@ -26,6 +26,16 @@ test_that("geom_glycan maps structures to x and y positions", {
   expect_setequal(GeomGlycan$required_aes, c("x", "y", "structure"))
 })
 
+test_that("geom_glycan red_end overrides its style", {
+  style <- style_glydraw(red_end = "~")
+
+  expect_identical(geom_glycan(style = style)$geom_params$red_end, "~")
+  expect_identical(
+    geom_glycan(style = style, red_end = "Reducing end")$geom_params$red_end,
+    "Reducing end"
+  )
+})
+
 test_that("geom_glycan preserves mapped glycan structure vectors", {
   structures <- glyrepr::as_glycan_structure(c(
     "GalNAc(a1-",

--- a/tests/testthat/test-guide-glycan.R
+++ b/tests/testthat/test-guide-glycan.R
@@ -176,6 +176,19 @@ test_that("guide_glycan draws scale labels as cartoons", {
   )))
 })
 
+test_that("guide_glycan red_end overrides its style", {
+  style <- style_glydraw(red_end = "~")
+
+  expect_identical(guide_glycan(style = style)$params$glycan_red_end, "~")
+  expect_identical(
+    guide_glycan(
+      style = style,
+      red_end = "Reducing end"
+    )$params$glycan_red_end,
+    "Reducing end"
+  )
+})
+
 test_that("guide_glycan anchors labels at their reducing ends by default", {
   structures <- c(
     paste0(

--- a/tests/testthat/test-scale-glycan.R
+++ b/tests/testthat/test-scale-glycan.R
@@ -478,6 +478,29 @@ test_that("glycan axis labels support reducing-end annotations", {
   )
 })
 
+test_that("glycan scales red_end overrides their styles", {
+  style <- style_glydraw(red_end = "~")
+
+  expect_identical(
+    scale_x_glycan(style = style)$guide$params$glycan_red_end,
+    "~"
+  )
+  expect_identical(
+    scale_x_glycan(
+      style = style,
+      red_end = "Reducing end"
+    )$guide$params$glycan_red_end,
+    "Reducing end"
+  )
+  expect_identical(
+    scale_y_glycan(
+      style = style,
+      red_end = "Reducing end"
+    )$guide$params$glycan_red_end,
+    "Reducing end"
+  )
+})
+
 test_that("glycan axis scales use plain cartoon parameters", {
   data <- data.frame(
     structure = "Gal(b1-3)GalNAc(a1-",


### PR DESCRIPTION
## Summary

- Add an explicit `red_end` argument to the main glycan drawing APIs.
- Use `style$red_end` when `red_end = NULL`, while non-`NULL` values override the reusable style without modifying it.
- Append the argument to public signatures to preserve positional compatibility.
- Update documentation, NEWS, and cross-interface regression tests.

## Verification

```r
style <- style_glygen()

# Inherits "~" from the style
draw_cartoon("Gal(b1-3)GalNAc(a1-", style = style)

# Overrides the style value
draw_cartoon(
  "Gal(b1-3)GalNAc(a1-",
  style = style,
  red_end = "Reducing end"
)
```

- `devtools::test()` — 604 passed
- `devtools::check(error_on = "warning", manual = FALSE)` — 0 errors, 0 warnings, 1 system-clock note
- `pkgdown::check_pkgdown()` — no problems
