### PR TITLE
Fix sketch cartoons to ignore style fonts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 
 * New `red_end_length` style option controls the length of the reducing-end line; at `0`, the line and all `red_end` decorations are omitted while the axis-aligned core anomer annotation remains. (#80)
 
-* New `draw_cartoon_sketch()` draws hand-sketched glycan cartoons with reproducible rough strokes, patterned residue fills, optional drawing media, and the same layout, annotation, orientation, highlighting, styling, sizing, and saving behavior as `draw_cartoon()`. Sketch cartoons always use their handwriting font, ignoring `font_family` in style presets. (#77)
+* New `draw_cartoon_sketch()` draws hand-sketched glycan cartoons with reproducible rough strokes, patterned residue fills, optional drawing media, and the same layout, annotation, orientation, highlighting, styling, sizing, and saving behavior as `draw_cartoon()`. Sketch cartoons always use their handwriting font, ignoring `font_family` in style presets. (#77, #81)
 
 * `style_glydraw()` replaces `glydraw_style()` as the single reusable interface for tuning cartoon appearance; `show_linkage` and `orient` are explicit drawing controls instead of style fields, and explicit `red_end = NULL` inherits the style value. New `style_glygen()`, `style_snfg()`, and `style_glycoworkbench()` provide reusable presets for common glycan-drawing conventions. (#73, #79)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 
 * New `red_end_length` style option controls the length of the reducing-end line; at `0`, the line and all `red_end` decorations are omitted while the axis-aligned core anomer annotation remains. (#80)
 
-* New `draw_cartoon_sketch()` draws hand-sketched glycan cartoons with reproducible rough strokes, patterned residue fills, optional drawing media, and the same layout, annotation, orientation, highlighting, styling, sizing, and saving behavior as `draw_cartoon()`. (#77)
+* New `draw_cartoon_sketch()` draws hand-sketched glycan cartoons with reproducible rough strokes, patterned residue fills, optional drawing media, and the same layout, annotation, orientation, highlighting, styling, sizing, and saving behavior as `draw_cartoon()`. Sketch cartoons always use their handwriting font, ignoring `font_family` in style presets. (#77)
 
 * `style_glydraw()` replaces `glydraw_style()` as the single reusable interface for tuning cartoon appearance; `show_linkage` and `orient` are explicit drawing controls instead of style fields, and explicit `red_end = NULL` inherits the style value. New `style_glygen()`, `style_snfg()`, and `style_glycoworkbench()` provide reusable presets for common glycan-drawing conventions. (#73, #79)
 

--- a/R/draw-cartoon-sketch.R
+++ b/R/draw-cartoon-sketch.R
@@ -5,10 +5,9 @@
 #' layout, annotations, orientation, and sizing are otherwise identical to
 #' [draw_cartoon()].
 #'
-#' When `style_glydraw(font_family = "")` is used, the default, sketch cartoons
-#' prefer an installed handwriting font that contains Greek alpha, Greek beta,
-#' and decimal digits so all linkage labels use one font. An explicitly
-#' selected `font_family` is used unchanged.
+#' Sketch cartoons always use a handwriting font, ignoring `font_family` in
+#' `style`. They prefer an installed sketch-style font that contains Greek
+#' alpha, Greek beta, and decimal digits so all linkage labels use one font.
 #'
 #' @inheritParams draw_cartoon
 #' @param show_linkage Show glycosidic linkage annotations or not. Defaults to

--- a/R/internal-sketch.R
+++ b/R/internal-sketch.R
@@ -22,7 +22,7 @@
   plot <- .add_sketch_cartoon_text_layers(plot, grob)
   font_family <- attr(plot, "glydraw_sketch_font_family", exact = TRUE)
   if (is.null(font_family)) {
-    font_family <- grob$font_family
+    font_family <- .resolve_sketch_text_family()
   }
   plot <- .add_cartoon_text_bounds(plot, grob$annotation_data$bounds)
   plot <- .add_sketch_reducing_end_layers(plot, grob, sketch)
@@ -181,7 +181,7 @@
   if (nrow(annotation) == 0) {
     return(plot)
   }
-  family <- .resolve_sketch_text_family(grob$font_family)
+  family <- .resolve_sketch_text_family()
   annotation$annot_label <- .sketch_annotation_labels(annotation)
 
   text_layer <- ggsketch::geom_sketch_text(
@@ -226,18 +226,10 @@
 
 #' Resolve a handwriting font that covers all sketch annotation glyphs
 #'
-#' @param font_family Font family requested by the glydraw style. An empty
-#'   string requests automatic sketch-font selection.
-#'
-#' @returns A character font family. Explicitly requested families are returned
-#'   unchanged. Automatic selection prefers an available handwriting font that
-#'   contains Greek alpha, Greek beta, and decimal digits.
+#' @returns A character font family. Selection prefers an available handwriting
+#'   font that contains Greek alpha, Greek beta, and decimal digits.
 #' @noRd
-.resolve_sketch_text_family <- function(font_family) {
-  if (!identical(font_family, "")) {
-    return(font_family)
-  }
-
+.resolve_sketch_text_family <- function() {
   resolved <- ggsketch::geom_sketch_text()$aes_params$family
   if (
     !requireNamespace("systemfonts", quietly = TRUE) ||

--- a/man/draw_cartoon_sketch.Rd
+++ b/man/draw_cartoon_sketch.Rd
@@ -83,10 +83,9 @@ layout, annotations, orientation, and sizing are otherwise identical to
 \code{\link[=draw_cartoon]{draw_cartoon()}}.
 }
 \details{
-When \code{style_glydraw(font_family = "")} is used, the default, sketch cartoons
-prefer an installed handwriting font that contains Greek alpha, Greek beta,
-and decimal digits so all linkage labels use one font. An explicitly
-selected \code{font_family} is used unchanged.
+Sketch cartoons always use a handwriting font, ignoring \code{font_family} in
+\code{style}. They prefer an installed sketch-style font that contains Greek
+alpha, Greek beta, and decimal digits so all linkage labels use one font.
 }
 \examples{
 if (requireNamespace("ggsketch", quietly = TRUE)) {

--- a/tests/testthat/test-draw-cartoon-sketch.R
+++ b/tests/testthat/test-draw-cartoon-sketch.R
@@ -49,6 +49,39 @@ test_that("draw_cartoon_sketch uses one handwriting font for text labels", {
   }
 })
 
+test_that("draw_cartoon_sketch ignores font_family in every style preset", {
+  styles <- list(
+    style_glydraw(font_family = "serif"),
+    style_glygen(font_family = "serif"),
+    style_snfg(font_family = "serif"),
+    style_glycoworkbench(font_family = "serif")
+  )
+  expected <- .resolve_sketch_text_family()
+
+  for (style in styles) {
+    plot <- draw_cartoon_sketch(
+      "Gal(b1-3)GalNAc(a1-",
+      style = style,
+      seed = 1
+    )
+    text_layer <- Filter(
+      \(layer) inherits(layer$geom, "GeomText"),
+      plot$layers
+    )[[1]]
+
+    expect_identical(text_layer$aes_params$family, expected)
+    expect_identical(attr(plot, "glydraw_font_family"), expected)
+  }
+
+  without_text <- draw_cartoon_sketch(
+    "Gal(b1-3)GalNAc(b1-",
+    show_linkage = FALSE,
+    style = style_glydraw(font_family = "serif"),
+    seed = 1
+  )
+  expect_identical(attr(without_text, "glydraw_font_family"), expected)
+})
+
 test_that("sketch text preserves unknown and substituent labels", {
   annotation <- data.frame(
     annot = c("?", "??", '?1', '~"?"', "3S,6S", "Ser/Thr")
@@ -196,7 +229,10 @@ test_that("draw_cartoon_sketch builds a fixed-size sketch cartoon", {
   expect_s3_class(plot$layers[[3]]$geom, "GeomSketchCircle")
   expect_s3_class(plot$layers[[4]]$geom, "GeomSketchPolygon")
   expect_named(attr(plot, "glydraw_size_px"), c("width", "height"))
-  expect_equal(attr(plot, "glydraw_font_family"), "sans")
+  expect_equal(
+    attr(plot, "glydraw_font_family"),
+    .resolve_sketch_text_family()
+  )
 })
 
 test_that("draw_cartoon_sketch preserves cartoon controls", {


### PR DESCRIPTION
## Summary

Ensure `draw_cartoon_sketch()` always uses its sketch-style handwriting font, regardless of the `font_family` stored in a glydraw style.

## Details

- Resolve the sketch font without consulting `style$font_family`.
- Preserve the resolved sketch font in cartoon metadata, including cartoons without text annotations.
- Document that sketch rendering ignores style font families.
- Cover `style_glydraw()`, `style_glygen()`, `style_snfg()`, and `style_glycoworkbench()`.

## Verification

```r
styles <- list(
  style_glydraw(font_family = "serif"),
  style_glygen(font_family = "serif"),
  style_snfg(font_family = "serif"),
  style_glycoworkbench(font_family = "serif")
)

lapply(styles, \(style) {
  draw_cartoon_sketch("Gal(b1-3)GalNAc(a1-", style = style, seed = 1)
})
```

- Focused sketch tests: 52 passed.
- Full package test suite: 718 passed.
- `devtools::check(error_on = "warning")`: 0 errors, 0 warnings, 1 environment-only clock-verification NOTE.
