### PR TITLE
feat: add orientation controls to glycan labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ## New features
 
+* `scale_x_glycan()`, `scale_y_glycan()`, and `anno_glycan()` gain an `orient` argument. Its `NULL` default automatically selects a drawing orientation from the displayed axis position or annotation side.
 * `anno_glycan()` uses glycan cartoons as row or column labels in ComplexHeatmap heatmaps, with clustering-aware ordering and the sizing, anchoring, rotation, nudging, and styling controls of glycan axis scales. (#67)
 * `draw_cartoon_sketch()` draws hand-sketched glycan cartoons with reproducible rough strokes, patterned residue fills, optional drawing media, and the same layout, annotation, orientation, highlighting, styling, sizing, and saving behavior as `draw_cartoon()`. Sketch cartoons always use their handwriting font, ignoring `font_family` in style presets. (#77, #81)
 * `font_family` style option controls the font used for text annotations across glycan cartoons, including alpha and beta anomer labels. (#69)

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 ## New features
 
-* `scale_x_glycan()`, `scale_y_glycan()`, and `anno_glycan()` gain an `orient` argument. Its `NULL` default automatically selects a drawing orientation from the displayed axis position or annotation side. (#84)
+* `scale_x_glycan()`, `scale_y_glycan()`, and `anno_glycan()` gain an `orient` argument. Its `NULL` default automatically selects a drawing orientation from the displayed axis position or annotation side. Default justification follows compatible position-orientation combinations and centers other combinations. (#84)
 * `anno_glycan()` uses glycan cartoons as row or column labels in ComplexHeatmap heatmaps, with clustering-aware ordering and the sizing, anchoring, rotation, nudging, and styling controls of glycan axis scales. (#67)
 * `draw_cartoon_sketch()` draws hand-sketched glycan cartoons with reproducible rough strokes, patterned residue fills, optional drawing media, and the same layout, annotation, orientation, highlighting, styling, sizing, and saving behavior as `draw_cartoon()`. Sketch cartoons always use their handwriting font, ignoring `font_family` in style presets. (#77, #81)
 * `font_family` style option controls the font used for text annotations across glycan cartoons, including alpha and beta anomer labels. (#69)

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 ## New features
 
-* `scale_x_glycan()`, `scale_y_glycan()`, and `anno_glycan()` gain an `orient` argument. Its `NULL` default automatically selects a drawing orientation from the displayed axis position or annotation side.
+* `scale_x_glycan()`, `scale_y_glycan()`, and `anno_glycan()` gain an `orient` argument. Its `NULL` default automatically selects a drawing orientation from the displayed axis position or annotation side. (#84)
 * `anno_glycan()` uses glycan cartoons as row or column labels in ComplexHeatmap heatmaps, with clustering-aware ordering and the sizing, anchoring, rotation, nudging, and styling controls of glycan axis scales. (#67)
 * `draw_cartoon_sketch()` draws hand-sketched glycan cartoons with reproducible rough strokes, patterned residue fills, optional drawing media, and the same layout, annotation, orientation, highlighting, styling, sizing, and saving behavior as `draw_cartoon()`. Sketch cartoons always use their handwriting font, ignoring `font_family` in style presets. (#77, #81)
 * `font_family` style option controls the font used for text annotations across glycan cartoons, including alpha and beta anomer labels. (#69)

--- a/R/anno-glycan.R
+++ b/R/anno-glycan.R
@@ -33,10 +33,14 @@
 #' @param orient Glycan drawing orientation. `NULL`, the default, selects the
 #'   orientation from `side`: `"up"` for `"bottom"` or `"top"`, `"left"` for
 #'   `"left"`, and `"right"` for `"right"`.
-#' @param hjust Horizontal justification. `NULL` uses [hjust_red_end()] for
-#'   column labels and `1` for row labels.
-#' @param vjust Vertical justification. `NULL` uses `0` for column labels and
-#'   [vjust_red_end()] for row labels.
+#' @param hjust Horizontal justification. `NULL` uses [hjust_red_end()] for a
+#'   top or bottom annotation with a vertical orientation, `1` or `0` for a
+#'   left or right annotation with a horizontal orientation, respectively, and
+#'   `0.5` for other side-orientation combinations.
+#' @param vjust Vertical justification. `NULL` uses `0` for a top or bottom
+#'   annotation with a vertical orientation, [vjust_red_end()] for a left or
+#'   right annotation with a horizontal orientation, and `0.5` for other
+#'   side-orientation combinations.
 #' @param nudge_x Horizontal adjustment of each cartoon, in millimetres.
 #'   Positive values move cartoons to the right. Defaults to `0`.
 #' @param nudge_y Vertical adjustment of each cartoon, in millimetres. Positive
@@ -110,12 +114,12 @@ anno_glycan <- function(
   which <- rlang::arg_match(which)
   side <- .resolve_glycan_annotation_side(side, which)
   orient <- .resolve_glycan_label_orient(orient, side)
-  if (is.null(hjust)) {
-    hjust <- switch(which, column = hjust_red_end(), row = 1)
-  }
-  if (is.null(vjust)) {
-    vjust <- switch(which, column = 0, row = vjust_red_end())
-  }
+  justification <- .resolve_glycan_label_justification(
+    hjust,
+    vjust,
+    side,
+    orient
+  )
   checkmate::assert_flag(show_name)
   red_end <- .resolve_red_end(red_end, style)
 
@@ -123,8 +127,8 @@ anno_glycan <- function(
     orient = orient,
     size = size,
     angle = angle,
-    hjust = hjust,
-    vjust = vjust,
+    hjust = justification$hjust,
+    vjust = justification$vjust,
     nudge_x = nudge_x,
     nudge_y = nudge_y,
     show_linkage = show_linkage,

--- a/R/anno-glycan.R
+++ b/R/anno-glycan.R
@@ -30,6 +30,9 @@
 #'   `0.4`.
 #' @param angle Rotation in degrees applied to each cartoon independently of
 #'   its drawing orientation. Defaults to `0`.
+#' @param orient Glycan drawing orientation. `NULL`, the default, selects the
+#'   orientation from `side`: `"up"` for `"bottom"` or `"top"`, `"left"` for
+#'   `"left"`, and `"right"` for `"right"`.
 #' @param hjust Horizontal justification. `NULL` uses [hjust_red_end()] for
 #'   column labels and `1` for row labels.
 #' @param vjust Vertical justification. `NULL` uses `0` for column labels and
@@ -95,7 +98,8 @@ anno_glycan <- function(
   width = NULL,
   height = NULL,
   show_name = FALSE,
-  red_end = NULL
+  red_end = NULL,
+  orient = NULL
 ) {
   if (!requireNamespace("ComplexHeatmap", quietly = TRUE)) {
     cli::cli_abort(
@@ -105,7 +109,7 @@ anno_glycan <- function(
   .validate_glycan_annotation_structures(structure)
   which <- rlang::arg_match(which)
   side <- .resolve_glycan_annotation_side(side, which)
-  orient <- switch(which, column = "up", row = "left")
+  orient <- .resolve_glycan_label_orient(orient, side)
   if (is.null(hjust)) {
     hjust <- switch(which, column = hjust_red_end(), row = 1)
   }

--- a/R/scale-glycan.R
+++ b/R/scale-glycan.R
@@ -27,10 +27,14 @@
 #' @param orient Glycan drawing orientation. `NULL`, the default, selects the
 #'   orientation from the displayed axis position: `"up"` for `"bottom"` or
 #'   `"top"`, `"left"` for `"left"`, and `"right"` for `"right"`.
-#' @param hjust Horizontal justification. Vertical x-axis cartoons default to
-#'   [hjust_red_end()], while horizontal y-axis cartoons default to `1`.
-#' @param vjust Vertical justification. Vertical x-axis cartoons default to
-#'   `0`, while horizontal y-axis cartoons default to [vjust_red_end()].
+#' @param hjust Horizontal justification. When omitted, cartoons on a top or
+#'   bottom axis with a vertical orientation use [hjust_red_end()]. Cartoons on
+#'   a left or right axis with a horizontal orientation use `1` or `0`,
+#'   respectively. Other position-orientation combinations use `0.5`.
+#' @param vjust Vertical justification. When omitted, cartoons on a top or
+#'   bottom axis with a vertical orientation use `0`. Cartoons on a left or
+#'   right axis with a horizontal orientation use [vjust_red_end()]. Other
+#'   position-orientation combinations use `0.5`.
 #' @param nudge_x Horizontal adjustment of each cartoon, in millimetres.
 #'   Positive values move cartoons to the right. When this moves cartoons
 #'   toward or away from a y-axis title, the title moves with them to preserve
@@ -81,15 +85,25 @@ scale_x_glycan <- function(
   orient = NULL
 ) {
   orient_auto <- is.null(orient)
+  hjust_auto <- missing(hjust)
+  vjust_auto <- missing(vjust)
   orient <- .resolve_glycan_label_orient(orient, position)
+  justification <- .resolve_glycan_label_justification(
+    hjust = if (hjust_auto) NULL else hjust,
+    vjust = if (vjust_auto) NULL else vjust,
+    side = position,
+    orient = orient
+  )
   red_end <- .resolve_red_end(red_end, style)
   guide <- .new_glycan_axis_guide(
     orient = orient,
     orient_auto = orient_auto,
+    hjust_auto = hjust_auto,
+    vjust_auto = vjust_auto,
     size = size,
     angle = angle,
-    hjust = hjust,
-    vjust = vjust,
+    hjust = justification$hjust,
+    vjust = justification$vjust,
     nudge_x = nudge_x,
     nudge_y = nudge_y,
     show_linkage = show_linkage,
@@ -140,15 +154,25 @@ scale_y_glycan <- function(
   orient = NULL
 ) {
   orient_auto <- is.null(orient)
+  hjust_auto <- missing(hjust)
+  vjust_auto <- missing(vjust)
   orient <- .resolve_glycan_label_orient(orient, position)
+  justification <- .resolve_glycan_label_justification(
+    hjust = if (hjust_auto) NULL else hjust,
+    vjust = if (vjust_auto) NULL else vjust,
+    side = position,
+    orient = orient
+  )
   red_end <- .resolve_red_end(red_end, style)
   guide <- .new_glycan_axis_guide(
     orient = orient,
     orient_auto = orient_auto,
+    hjust_auto = hjust_auto,
+    vjust_auto = vjust_auto,
     size = size,
     angle = angle,
-    hjust = hjust,
-    vjust = vjust,
+    hjust = justification$hjust,
+    vjust = justification$vjust,
     nudge_x = nudge_x,
     nudge_y = nudge_y,
     show_linkage = show_linkage,
@@ -182,6 +206,10 @@ scale_y_glycan <- function(
 #' @param orient Glycan drawing orientation.
 #' @param orient_auto Whether the guide should resolve `orient` from its
 #'   displayed position.
+#' @param hjust_auto Whether the guide should resolve `hjust` from its displayed
+#'   position and orientation.
+#' @param vjust_auto Whether the guide should resolve `vjust` from its displayed
+#'   position and orientation.
 #' @param size Positive whole-cartoon scale multiplier.
 #' @param angle Rotation in degrees applied to each cartoon.
 #' @param hjust Horizontal glycan justification.
@@ -204,6 +232,8 @@ scale_y_glycan <- function(
 .new_glycan_axis_guide <- function(
   orient,
   orient_auto,
+  hjust_auto,
+  vjust_auto,
   size,
   angle,
   hjust,
@@ -251,30 +281,12 @@ scale_y_glycan <- function(
     cap = "none",
     glycan_orient = options$orient,
     glycan_orient_auto = orient_auto,
+    glycan_hjust_auto = hjust_auto,
+    glycan_vjust_auto = vjust_auto,
     glycan_size = options$size,
     glycan_angle = options$angle,
     glycan_hjust = options$hjust,
     glycan_vjust = options$vjust,
-    glycan_x_hjust = if (.is_vertical_glycan_orientation(options$orient)) {
-      options$hjust
-    } else {
-      .hjust_red_end
-    },
-    glycan_x_vjust = if (.is_vertical_glycan_orientation(options$orient)) {
-      options$vjust
-    } else {
-      0
-    },
-    glycan_y_hjust = if (.is_horizontal_glycan_orientation(options$orient)) {
-      options$hjust
-    } else {
-      1
-    },
-    glycan_y_vjust = if (.is_horizontal_glycan_orientation(options$orient)) {
-      options$vjust
-    } else {
-      .vjust_red_end
-    },
     glycan_nudge_x = options$nudge_x,
     glycan_nudge_y = options$nudge_y,
     glycan_show_linkage = options$show_linkage,
@@ -319,6 +331,44 @@ scale_y_glycan <- function(
     cli::cli_abort(
       "{.arg side} must be one of \"bottom\", \"top\", \"left\", or \"right\"."
     )
+  )
+}
+
+#' Resolve default glycan label justifications
+#'
+#' @param hjust Requested horizontal justification or `NULL`.
+#' @param vjust Requested vertical justification or `NULL`.
+#' @param side Side on which the glycan label is displayed.
+#' @param orient Resolved glycan drawing orientation.
+#'
+#' @returns A list containing resolved `hjust` and `vjust` values.
+#' @noRd
+.resolve_glycan_label_justification <- function(
+  hjust,
+  vjust,
+  side,
+  orient
+) {
+  side_is_vertical <- side %in% c("left", "right")
+  orient_is_vertical <- .is_vertical_glycan_orientation(orient)
+
+  if (!side_is_vertical && orient_is_vertical) {
+    default_hjust <- hjust_red_end()
+    default_vjust <- 0
+  } else if (
+    side_is_vertical &&
+      .is_horizontal_glycan_orientation(orient)
+  ) {
+    default_hjust <- if (side == "left") 1 else 0
+    default_vjust <- vjust_red_end()
+  } else {
+    default_hjust <- 0.5
+    default_vjust <- 0.5
+  }
+
+  list(
+    hjust = if (is.null(hjust)) default_hjust else hjust,
+    vjust = if (is.null(vjust)) default_vjust else vjust
   )
 }
 
@@ -705,14 +755,12 @@ GuideGlycanAxis <- ggplot2::ggproto(
     list(
       glycan_orient = "left",
       glycan_orient_auto = FALSE,
+      glycan_hjust_auto = FALSE,
+      glycan_vjust_auto = FALSE,
       glycan_size = 0.4,
       glycan_angle = 0,
       glycan_hjust = 0.5,
       glycan_vjust = 0.5,
-      glycan_x_hjust = .hjust_red_end,
-      glycan_x_vjust = 0,
-      glycan_y_hjust = 1,
-      glycan_y_vjust = .vjust_red_end,
       glycan_nudge_x = 0,
       glycan_nudge_y = 0,
       glycan_show_linkage = FALSE,
@@ -735,14 +783,23 @@ GuideGlycanAxis <- ggplot2::ggproto(
         NULL,
         params$position
       )
-      if (params$vertical) {
-        params$glycan_hjust <- params$glycan_y_hjust
-        params$glycan_vjust <- params$glycan_y_vjust
-      } else {
-        params$glycan_hjust <- params$glycan_x_hjust
-        params$glycan_vjust <- params$glycan_x_vjust
-      }
     }
+    justification <- .resolve_glycan_label_justification(
+      hjust = if (params$glycan_hjust_auto) {
+        NULL
+      } else {
+        params$glycan_hjust
+      },
+      vjust = if (params$glycan_vjust_auto) {
+        NULL
+      } else {
+        params$glycan_vjust
+      },
+      side = params$position,
+      orient = params$glycan_orient
+    )
+    params$glycan_hjust <- justification$hjust
+    params$glycan_vjust <- justification$vjust
     .validate_red_end_justification_orientation(
       params$glycan_hjust,
       params$glycan_vjust,

--- a/R/scale-glycan.R
+++ b/R/scale-glycan.R
@@ -24,6 +24,9 @@
 #'   Defaults to `0.4`.
 #' @param angle Rotation in degrees applied to each axis-label cartoon,
 #'   independently of the cartoon orientation. Defaults to `0`.
+#' @param orient Glycan drawing orientation. `NULL`, the default, selects the
+#'   orientation from the displayed axis position: `"up"` for `"bottom"` or
+#'   `"top"`, `"left"` for `"left"`, and `"right"` for `"right"`.
 #' @param hjust Horizontal justification. Vertical x-axis cartoons default to
 #'   [hjust_red_end()], while horizontal y-axis cartoons default to `1`.
 #' @param vjust Vertical justification. Vertical x-axis cartoons default to
@@ -74,11 +77,15 @@ scale_x_glycan <- function(
   nudge_y = 0,
   show_linkage = TRUE,
   style = style_glydraw(),
-  red_end = NULL
+  red_end = NULL,
+  orient = NULL
 ) {
+  orient_auto <- is.null(orient)
+  orient <- .resolve_glycan_label_orient(orient, position)
   red_end <- .resolve_red_end(red_end, style)
   guide <- .new_glycan_axis_guide(
-    orient = "up",
+    orient = orient,
+    orient_auto = orient_auto,
     size = size,
     angle = angle,
     hjust = hjust,
@@ -129,11 +136,15 @@ scale_y_glycan <- function(
   nudge_y = 0,
   show_linkage = TRUE,
   style = style_glydraw(),
-  red_end = NULL
+  red_end = NULL,
+  orient = NULL
 ) {
+  orient_auto <- is.null(orient)
+  orient <- .resolve_glycan_label_orient(orient, position)
   red_end <- .resolve_red_end(red_end, style)
   guide <- .new_glycan_axis_guide(
-    orient = "left",
+    orient = orient,
+    orient_auto = orient_auto,
     size = size,
     angle = angle,
     hjust = hjust,
@@ -169,6 +180,8 @@ scale_y_glycan <- function(
 #' Create a ggplot2 guide that draws glycan cartoons as axis labels
 #'
 #' @param orient Glycan drawing orientation.
+#' @param orient_auto Whether the guide should resolve `orient` from its
+#'   displayed position.
 #' @param size Positive whole-cartoon scale multiplier.
 #' @param angle Rotation in degrees applied to each cartoon.
 #' @param hjust Horizontal glycan justification.
@@ -190,6 +203,7 @@ scale_y_glycan <- function(
 #' @noRd
 .new_glycan_axis_guide <- function(
   orient,
+  orient_auto,
   size,
   angle,
   hjust,
@@ -236,6 +250,7 @@ scale_y_glycan <- function(
     minor.ticks = FALSE,
     cap = "none",
     glycan_orient = options$orient,
+    glycan_orient_auto = orient_auto,
     glycan_size = options$size,
     glycan_angle = options$angle,
     glycan_hjust = options$hjust,
@@ -277,6 +292,33 @@ scale_y_glycan <- function(
     position = ggplot2::waiver(),
     name = "axis",
     super = GuideGlycanAxis
+  )
+}
+
+#' Resolve an automatic glycan label orientation
+#'
+#' @param orient Requested glycan orientation or `NULL`.
+#' @param side Side on which the glycan label is displayed.
+#'
+#' @returns A resolved glycan drawing orientation.
+#' @noRd
+.resolve_glycan_label_orient <- function(orient, side) {
+  if (!is.null(orient)) {
+    return(rlang::arg_match(
+      orient,
+      c("left", "right", "up", "down")
+    ))
+  }
+
+  switch(
+    side,
+    bottom = "up",
+    top = "up",
+    left = "left",
+    right = "right",
+    cli::cli_abort(
+      "{.arg side} must be one of \"bottom\", \"top\", \"left\", or \"right\"."
+    )
   )
 }
 
@@ -436,6 +478,7 @@ scale_y_glycan <- function(
     )
   )
   grob$glydraw_scale <- params$glycan_size
+  grob$glydraw_orient <- params$glycan_orient
   grob$glydraw_angle <- params$glycan_angle
   grob$glydraw_hjust <- params$glycan_hjust
   grob$glydraw_vjust <- params$glycan_vjust
@@ -661,6 +704,7 @@ GuideGlycanAxis <- ggplot2::ggproto(
     ggplot2:::GuideAxis$params,
     list(
       glycan_orient = "left",
+      glycan_orient_auto = FALSE,
       glycan_size = 0.4,
       glycan_angle = 0,
       glycan_hjust = 0.5,
@@ -686,14 +730,18 @@ GuideGlycanAxis <- ggplot2::ggproto(
   setup_params = function(params) {
     params <- ggplot2:::GuideAxis$setup_params(params)
 
-    if (params$vertical) {
-      params$glycan_orient <- "left"
-      params$glycan_hjust <- params$glycan_y_hjust
-      params$glycan_vjust <- params$glycan_y_vjust
-    } else {
-      params$glycan_orient <- "up"
-      params$glycan_hjust <- params$glycan_x_hjust
-      params$glycan_vjust <- params$glycan_x_vjust
+    if (params$glycan_orient_auto) {
+      params$glycan_orient <- .resolve_glycan_label_orient(
+        NULL,
+        params$position
+      )
+      if (params$vertical) {
+        params$glycan_hjust <- params$glycan_y_hjust
+        params$glycan_vjust <- params$glycan_y_vjust
+      } else {
+        params$glycan_hjust <- params$glycan_x_hjust
+        params$glycan_vjust <- params$glycan_x_vjust
+      }
     }
     .validate_red_end_justification_orientation(
       params$glycan_hjust,

--- a/man/anno_glycan.Rd
+++ b/man/anno_glycan.Rd
@@ -41,11 +41,15 @@ accept \code{"bottom"} or \code{"top"}; row annotations accept \code{"left"} or
 \item{angle}{Rotation in degrees applied to each cartoon independently of
 its drawing orientation. Defaults to \code{0}.}
 
-\item{hjust}{Horizontal justification. \code{NULL} uses \code{\link[=hjust_red_end]{hjust_red_end()}} for
-column labels and \code{1} for row labels.}
+\item{hjust}{Horizontal justification. \code{NULL} uses \code{\link[=hjust_red_end]{hjust_red_end()}} for a
+top or bottom annotation with a vertical orientation, \code{1} or \code{0} for a
+left or right annotation with a horizontal orientation, respectively, and
+\code{0.5} for other side-orientation combinations.}
 
-\item{vjust}{Vertical justification. \code{NULL} uses \code{0} for column labels and
-\code{\link[=vjust_red_end]{vjust_red_end()}} for row labels.}
+\item{vjust}{Vertical justification. \code{NULL} uses \code{0} for a top or bottom
+annotation with a vertical orientation, \code{\link[=vjust_red_end]{vjust_red_end()}} for a left or
+right annotation with a horizontal orientation, and \code{0.5} for other
+side-orientation combinations.}
 
 \item{nudge_x}{Horizontal adjustment of each cartoon, in millimetres.
 Positive values move cartoons to the right. Defaults to \code{0}.}

--- a/man/anno_glycan.Rd
+++ b/man/anno_glycan.Rd
@@ -19,7 +19,8 @@ anno_glycan(
   width = NULL,
   height = NULL,
   show_name = FALSE,
-  red_end = NULL
+  red_end = NULL,
+  orient = NULL
 )
 }
 \arguments{
@@ -70,6 +71,10 @@ names.}
 
 \item{red_end}{Reducing-end annotation. \code{NULL}, the default, uses \code{red_end}
 from \code{style}. A non-\code{NULL} value overrides \code{style$red_end}.}
+
+\item{orient}{Glycan drawing orientation. \code{NULL}, the default, selects the
+orientation from \code{side}: \code{"up"} for \code{"bottom"} or \code{"top"}, \code{"left"} for
+\code{"left"}, and \code{"right"} for \code{"right"}.}
 }
 \value{
 A ComplexHeatmap \code{AnnotationFunction} object.

--- a/man/scale_x_glycan.Rd
+++ b/man/scale_x_glycan.Rd
@@ -21,7 +21,8 @@ scale_x_glycan(
   nudge_y = 0,
   show_linkage = TRUE,
   style = style_glydraw(),
-  red_end = NULL
+  red_end = NULL,
+  orient = NULL
 )
 
 scale_y_glycan(
@@ -40,7 +41,8 @@ scale_y_glycan(
   nudge_y = 0,
   show_linkage = TRUE,
   style = style_glydraw(),
-  red_end = NULL
+  red_end = NULL,
+  orient = NULL
 )
 }
 \arguments{
@@ -91,6 +93,10 @@ appearance.}
 
 \item{red_end}{Reducing-end annotation. \code{NULL}, the default, uses \code{red_end}
 from \code{style}. A non-\code{NULL} value overrides \code{style$red_end}.}
+
+\item{orient}{Glycan drawing orientation. \code{NULL}, the default, selects the
+orientation from the displayed axis position: \code{"up"} for \code{"bottom"} or
+\code{"top"}, \code{"left"} for \code{"left"}, and \code{"right"} for \code{"right"}.}
 }
 \value{
 A ggplot2 discrete position scale.

--- a/man/scale_x_glycan.Rd
+++ b/man/scale_x_glycan.Rd
@@ -69,11 +69,15 @@ Defaults to \code{0.4}.}
 \item{angle}{Rotation in degrees applied to each axis-label cartoon,
 independently of the cartoon orientation. Defaults to \code{0}.}
 
-\item{hjust}{Horizontal justification. Vertical x-axis cartoons default to
-\code{\link[=hjust_red_end]{hjust_red_end()}}, while horizontal y-axis cartoons default to \code{1}.}
+\item{hjust}{Horizontal justification. When omitted, cartoons on a top or
+bottom axis with a vertical orientation use \code{\link[=hjust_red_end]{hjust_red_end()}}. Cartoons on
+a left or right axis with a horizontal orientation use \code{1} or \code{0},
+respectively. Other position-orientation combinations use \code{0.5}.}
 
-\item{vjust}{Vertical justification. Vertical x-axis cartoons default to
-\code{0}, while horizontal y-axis cartoons default to \code{\link[=vjust_red_end]{vjust_red_end()}}.}
+\item{vjust}{Vertical justification. When omitted, cartoons on a top or
+bottom axis with a vertical orientation use \code{0}. Cartoons on a left or
+right axis with a horizontal orientation use \code{\link[=vjust_red_end]{vjust_red_end()}}. Other
+position-orientation combinations use \code{0.5}.}
 
 \item{nudge_x}{Horizontal adjustment of each cartoon, in millimetres.
 Positive values move cartoons to the right. When this moves cartoons

--- a/tests/testthat/test-anno-glycan.R
+++ b/tests/testthat/test-anno-glycan.R
@@ -84,6 +84,26 @@ test_that("anno_glycan creates row and column annotation functions", {
   )
 })
 
+test_that("anno_glycan orientation follows side and can be overridden", {
+  skip_if_not_installed("ComplexHeatmap")
+  structure <- "Gal(b1-3)GalNAc(a1-"
+  bottom <- anno_glycan(structure, which = "column")
+  top <- anno_glycan(structure, which = "column", side = "top")
+  left <- anno_glycan(structure, which = "row")
+  right <- anno_glycan(structure, which = "row", side = "right")
+  overridden <- anno_glycan(
+    structure,
+    which = "column",
+    orient = "down"
+  )
+
+  expect_equal(bottom@var_env$grobs[[1]]$glydraw_orient, "up")
+  expect_equal(top@var_env$grobs[[1]]$glydraw_orient, "up")
+  expect_equal(left@var_env$grobs[[1]]$glydraw_orient, "left")
+  expect_equal(right@var_env$grobs[[1]]$glydraw_orient, "right")
+  expect_equal(overridden@var_env$grobs[[1]]$glydraw_orient, "down")
+})
+
 test_that("anno_glycan accepts structure vectors and preserves duplicates", {
   skip_if_not_installed("ComplexHeatmap")
   structures <- glyrepr::as_glycan_structure(c(

--- a/tests/testthat/test-anno-glycan.R
+++ b/tests/testthat/test-anno-glycan.R
@@ -96,12 +96,34 @@ test_that("anno_glycan orientation follows side and can be overridden", {
     which = "column",
     orient = "down"
   )
+  column_unusual <- anno_glycan(
+    structure,
+    which = "column",
+    orient = "left"
+  )
+  row_unusual <- anno_glycan(
+    structure,
+    which = "row",
+    orient = "up"
+  )
 
   expect_equal(bottom@var_env$grobs[[1]]$glydraw_orient, "up")
   expect_equal(top@var_env$grobs[[1]]$glydraw_orient, "up")
   expect_equal(left@var_env$grobs[[1]]$glydraw_orient, "left")
   expect_equal(right@var_env$grobs[[1]]$glydraw_orient, "right")
   expect_equal(overridden@var_env$grobs[[1]]$glydraw_orient, "down")
+  expect_equal(bottom@var_env$grobs[[1]]$glydraw_hjust, hjust_red_end())
+  expect_equal(bottom@var_env$grobs[[1]]$glydraw_vjust, 0)
+  expect_equal(top@var_env$grobs[[1]]$glydraw_hjust, hjust_red_end())
+  expect_equal(top@var_env$grobs[[1]]$glydraw_vjust, 0)
+  expect_equal(left@var_env$grobs[[1]]$glydraw_hjust, 1)
+  expect_equal(left@var_env$grobs[[1]]$glydraw_vjust, vjust_red_end())
+  expect_equal(right@var_env$grobs[[1]]$glydraw_hjust, 0)
+  expect_equal(right@var_env$grobs[[1]]$glydraw_vjust, vjust_red_end())
+  expect_equal(column_unusual@var_env$grobs[[1]]$glydraw_hjust, 0.5)
+  expect_equal(column_unusual@var_env$grobs[[1]]$glydraw_vjust, 0.5)
+  expect_equal(row_unusual@var_env$grobs[[1]]$glydraw_hjust, 0.5)
+  expect_equal(row_unusual@var_env$grobs[[1]]$glydraw_vjust, 0.5)
 })
 
 test_that("anno_glycan accepts structure vectors and preserves duplicates", {

--- a/tests/testthat/test-draw-cartoon.R
+++ b/tests/testthat/test-draw-cartoon.R
@@ -649,9 +649,15 @@ test_that("main APIs expose only the red_end style override", {
   expect_true(all(
     c("show_linkage", "orient") %in% interface_arguments$export_cartoons
   ))
-  expect_true("show_linkage" %in% interface_arguments$scale_x_glycan)
-  expect_true("show_linkage" %in% interface_arguments$scale_y_glycan)
-  expect_true("show_linkage" %in% interface_arguments$anno_glycan)
+  expect_true(all(
+    c("show_linkage", "orient") %in% interface_arguments$scale_x_glycan
+  ))
+  expect_true(all(
+    c("show_linkage", "orient") %in% interface_arguments$scale_y_glycan
+  ))
+  expect_true(all(
+    c("show_linkage", "orient") %in% interface_arguments$anno_glycan
+  ))
   purrr::walk(
     interfaces,
     ~ expect_identical(formals(.x)$style, quote(style_glydraw()))
@@ -660,9 +666,25 @@ test_that("main APIs expose only the red_end style override", {
     interfaces,
     ~ expect_null(formals(.x)$red_end)
   )
+  new_orient_interfaces <- c(
+    "scale_x_glycan",
+    "scale_y_glycan",
+    "anno_glycan"
+  )
   purrr::walk(
-    interface_arguments,
+    interface_arguments[setdiff(
+      names(interface_arguments),
+      new_orient_interfaces
+    )],
     ~ expect_identical(tail(.x, 1), "red_end")
+  )
+  purrr::walk(
+    interface_arguments[new_orient_interfaces],
+    ~ expect_identical(tail(.x, 2), c("red_end", "orient"))
+  )
+  purrr::walk(
+    interfaces[new_orient_interfaces],
+    ~ expect_null(formals(.x)$orient)
   )
 })
 

--- a/tests/testthat/test-scale-glycan.R
+++ b/tests/testthat/test-scale-glycan.R
@@ -231,6 +231,62 @@ test_that("glycan axis orientation follows position and can be overridden", {
   )
 })
 
+test_that("glycan axis justification defaults follow side and orientation", {
+  data <- data.frame(
+    structure = "Gal(b1-3)GalNAc(a1-",
+    value = 1
+  )
+  x_label <- function(position = "bottom", orient = NULL, flip = FALSE, ...) {
+    plot <- ggplot2::ggplot(
+      data,
+      ggplot2::aes(x = .data$structure, y = .data$value)
+    ) +
+      ggplot2::geom_col() +
+      scale_x_glycan(position = position, orient = orient, ...)
+    axis_name <- if (flip) "axis-l" else paste0("axis-", substr(position, 1, 1))
+    if (flip) {
+      plot <- plot + ggplot2::coord_flip()
+    }
+    .axis_glycan_labels(plot, axis_name)$children[[1]]
+  }
+  y_label <- function(position = "left", orient = NULL, ...) {
+    plot <- ggplot2::ggplot(
+      data,
+      ggplot2::aes(x = .data$value, y = .data$structure)
+    ) +
+      ggplot2::geom_col() +
+      scale_y_glycan(position = position, orient = orient, ...)
+    axis_name <- paste0("axis-", substr(position, 1, 1))
+    .axis_glycan_labels(plot, axis_name)$children[[1]]
+  }
+
+  bottom <- x_label(orient = "down")
+  top <- x_label(position = "top", orient = "down")
+  left <- y_label(orient = "right")
+  right <- y_label(position = "right", orient = "left")
+  x_unusual <- x_label(orient = "left")
+  y_unusual <- y_label(orient = "up")
+  flipped_unusual <- x_label(orient = "up", flip = TRUE)
+  partial_override <- y_label(orient = "up", hjust = 0.25)
+
+  expect_equal(bottom$glydraw_hjust, hjust_red_end())
+  expect_equal(bottom$glydraw_vjust, 0)
+  expect_equal(top$glydraw_hjust, hjust_red_end())
+  expect_equal(top$glydraw_vjust, 0)
+  expect_equal(left$glydraw_hjust, 1)
+  expect_equal(left$glydraw_vjust, vjust_red_end())
+  expect_equal(right$glydraw_hjust, 0)
+  expect_equal(right$glydraw_vjust, vjust_red_end())
+  expect_equal(x_unusual$glydraw_hjust, 0.5)
+  expect_equal(x_unusual$glydraw_vjust, 0.5)
+  expect_equal(y_unusual$glydraw_hjust, 0.5)
+  expect_equal(y_unusual$glydraw_vjust, 0.5)
+  expect_equal(flipped_unusual$glydraw_hjust, 0.5)
+  expect_equal(flipped_unusual$glydraw_vjust, 0.5)
+  expect_equal(partial_override$glydraw_hjust, 0.25)
+  expect_equal(partial_override$glydraw_vjust, 0.5)
+})
+
 test_that("glycan axis alignment can be adjusted", {
   data <- data.frame(
     structure = "Gal(b1-3)GalNAc(a1-",

--- a/tests/testthat/test-scale-glycan.R
+++ b/tests/testthat/test-scale-glycan.R
@@ -167,12 +167,68 @@ test_that("glycan axis scales adapt their configuration to coord_flip", {
   x_label <- .axis_glycan_labels(x_plot, "axis-l")$children[[1]]
   y_label <- .axis_glycan_labels(y_plot, "axis-b")$children[[1]]
 
+  expect_equal(x_label$glydraw_orient, "left")
+  expect_equal(y_label$glydraw_orient, "up")
   expect_false(x_label$glydraw_axis_vertical)
   expect_equal(x_label$glydraw_hjust, 1)
   expect_equal(x_label$glydraw_vjust, vjust_red_end())
   expect_true(y_label$glydraw_axis_vertical)
   expect_equal(y_label$glydraw_hjust, hjust_red_end())
   expect_equal(y_label$glydraw_vjust, 0)
+})
+
+test_that("glycan axis orientation follows position and can be overridden", {
+  data <- data.frame(
+    structure = "Gal(b1-3)GalNAc(a1-",
+    value = 1
+  )
+  x_plot <- function(position = "bottom", orient = NULL) {
+    ggplot2::ggplot(
+      data,
+      ggplot2::aes(x = .data$structure, y = .data$value)
+    ) +
+      ggplot2::geom_col() +
+      scale_x_glycan(position = position, orient = orient)
+  }
+  y_plot <- function(position = "left", orient = NULL) {
+    ggplot2::ggplot(
+      data,
+      ggplot2::aes(x = .data$value, y = .data$structure)
+    ) +
+      ggplot2::geom_col() +
+      scale_y_glycan(position = position, orient = orient)
+  }
+
+  expect_equal(
+    .axis_glycan_labels(x_plot(), "axis-b")$children[[1]]$glydraw_orient,
+    "up"
+  )
+  expect_equal(
+    .axis_glycan_labels(x_plot("top"), "axis-t")$children[[1]]$glydraw_orient,
+    "up"
+  )
+  expect_equal(
+    .axis_glycan_labels(y_plot(), "axis-l")$children[[1]]$glydraw_orient,
+    "left"
+  )
+  expect_equal(
+    .axis_glycan_labels(y_plot("right"), "axis-r")$children[[1]]$glydraw_orient,
+    "right"
+  )
+  expect_equal(
+    .axis_glycan_labels(
+      x_plot(orient = "down"),
+      "axis-b"
+    )$children[[1]]$glydraw_orient,
+    "down"
+  )
+  expect_equal(
+    .axis_glycan_labels(
+      y_plot(orient = "right"),
+      "axis-l"
+    )$children[[1]]$glydraw_orient,
+    "right"
+  )
 })
 
 test_that("glycan axis alignment can be adjusted", {


### PR DESCRIPTION
## Summary
- add `orient = NULL` to `scale_x_glycan()`, `scale_y_glycan()`, and `anno_glycan()` while preserving positional compatibility
- automatically select orientation from the displayed axis position or annotation side, including after `coord_flip()`
- use `"up"` for top and bottom placements and follow left/right placements directly
- preserve explicitly supplied orientations and document the new behavior

## Verification
- `Rscript -e 'devtools::test()'`\n- `Rscript -e 'devtools::check()'`\n- `Rscript -e 'pkgdown::check_pkgdown()'`